### PR TITLE
test: e2e DHT discovery in echo example

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,3 +53,7 @@ jobs:
     
     - name: Build examples
       run: make examples
+
+    - name: Run echo example (DHT discovery e2e)
+      run: cd examples/echo && cargo run
+      timeout-minutes: 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,9 @@ client = [
 ]
 server = [
     "dep:axum",
+    "dep:data-encoding",
     "dep:http",
+    "dep:postcard",
     "dep:tokio",
     "dep:tokio-stream",
     "dep:tower",
@@ -38,6 +40,7 @@ server = [
 discovery = [
     "client",
     "dep:tokio-stream",
+    "dep:data-encoding",
     "iroh/address-lookup-mdns",
     "iroh/address-lookup-pkarr-dht",
     "dep:mainline",
@@ -60,6 +63,7 @@ thiserror = { version = "2.0", default-features = false }
 tracing = { version = "0.1", default-features = false }
 bytes = { version = "1.8", default-features = false }
 axum = { version = "0.8", default-features = false, optional = true }
+data-encoding = { version = "2.9", default-features = false, optional = true }
 
 # Mainline DHT discovery dependencies (optional)
 mainline = { version = "6", optional = true }
@@ -74,12 +78,14 @@ tracing-subscriber = "0.3"
 anyhow = "1.0"
 async-trait = "0.1"
 test-log = "0.2"
-cargo-release = "0.25"
 
 # Example dependencies
 clap = { version = "4.5", features = ["derive"] }
 prost = "0.14"
 tokio-stream = "0.1"
+
+[lints.clippy]
+pedantic = { level = "warn", priority = -1 }
 
 [build-dependencies]
 tonic-prost-build = "0.14"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tonic-iroh-transport"
 authors = ["George Whewell <george@hellas.ai>"]
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 description = "Transport layer for using tonic gRPC over iroh p2p connections"
 license = "MIT OR Apache-2.0"

--- a/Makefile
+++ b/Makefile
@@ -85,6 +85,11 @@ examples:
 	@echo "Building echo example..."
 	cd examples/echo && cargo build
 
+# Run echo example (DHT discovery e2e test)
+run-echo:
+	@echo "Running echo example (DHT discovery)..."
+	cd examples/echo && cargo run
+
 # Build examples in release mode
 examples-release:
 	@echo "Building chat example (release)..."

--- a/README.md
+++ b/README.md
@@ -218,6 +218,11 @@ let channel = EchoServiceServer::<EchoServiceImpl>::connect(&client_endpoint, se
 
 ### 7. Swarm discovery and racing connects
 
+The DHT backend is a bootstrap mechanism, not a trust anchor. Advertisements are
+signed by the advertising iroh node ID, so peers cannot forge each other's ads,
+but the shared DHT buckets are still globally writable and can be spammed or
+overwritten.
+
 ```rust
 use tonic_iroh_transport::swarm::{ServiceRegistry, DhtBackend};
 use futures::StreamExt;

--- a/examples/echo/Cargo.toml
+++ b/examples/echo/Cargo.toml
@@ -8,7 +8,7 @@ name = "echo"
 path = "src/main.rs"
 
 [dependencies]
-tonic-iroh-transport = { path = "../.." }
+tonic-iroh-transport = { path = "../..", features = ["discovery"] }
 tonic = { version = "0.14" }
 tonic-prost = "0.14"
 prost = "0.14"

--- a/src/client.rs
+++ b/src/client.rs
@@ -37,15 +37,16 @@ use tonic::transport::{Channel, Endpoint};
 use tower::service_fn;
 use tracing::{debug, info};
 
-/// Map a ConnectionError to an appropriate io::ErrorKind.
+/// Map a `ConnectionError` to an appropriate `io::ErrorKind`.
 fn connection_error_to_io(e: ConnectionError) -> std::io::Error {
     use std::io::ErrorKind;
     let kind = match &e {
         ConnectionError::VersionMismatch => ErrorKind::Unsupported,
         ConnectionError::TransportError(_) => ErrorKind::InvalidData,
         ConnectionError::ConnectionClosed(_) => ErrorKind::ConnectionAborted,
-        ConnectionError::ApplicationClosed(_) => ErrorKind::ConnectionReset,
-        ConnectionError::Reset => ErrorKind::ConnectionReset,
+        ConnectionError::ApplicationClosed(_) | ConnectionError::Reset => {
+            ErrorKind::ConnectionReset
+        }
         ConnectionError::TimedOut => ErrorKind::TimedOut,
         ConnectionError::LocallyClosed => ErrorKind::NotConnected,
         ConnectionError::CidsExhausted => ErrorKind::Other,
@@ -53,7 +54,7 @@ fn connection_error_to_io(e: ConnectionError) -> std::io::Error {
     std::io::Error::new(kind, e)
 }
 
-/// Map a ConnectingError to an appropriate io::Error.
+/// Map a `ConnectingError` to an appropriate `io::Error`.
 fn connecting_error_to_io(e: ConnectingError) -> std::io::Error {
     use std::io::ErrorKind;
     match e {
@@ -153,6 +154,7 @@ impl ConnectBuilder {
     ///
     /// Note: This wraps the connection with `tokio::time::timeout`.
     /// Iroh does not expose connect timeout configuration natively.
+    #[must_use] 
     pub fn connect_timeout(mut self, timeout: Duration) -> Self {
         self.connect_timeout = Some(timeout);
         self
@@ -165,6 +167,7 @@ impl ConnectBuilder {
     ///
     /// **Warning**: Modifying transport config may affect the ability
     /// to establish and maintain direct connections. Test carefully.
+    #[must_use] 
     pub fn transport_config(mut self, config: QuicTransportConfig) -> Self {
         self.transport_config = Some(config);
         self
@@ -204,6 +207,7 @@ impl IntoFuture for ConnectBuilder {
 /// # Ok(())
 /// # }
 /// ```
+#[must_use] 
 pub fn connect_alpn(
     endpoint: &iroh::Endpoint,
     target: EndpointAddr,
@@ -224,7 +228,7 @@ async fn connect_impl(
     if let Some(timeout) = connect_timeout {
         tokio::time::timeout(timeout, connect_future)
             .await
-            .map_err(|_| Error::connection(format!("connection timed out after {:?}", timeout)))?
+            .map_err(|_| Error::connection(format!("connection timed out after {timeout:?}")))?
     } else {
         connect_future.await
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -154,7 +154,7 @@ impl ConnectBuilder {
     ///
     /// Note: This wraps the connection with `tokio::time::timeout`.
     /// Iroh does not expose connect timeout configuration natively.
-    #[must_use] 
+    #[must_use]
     pub fn connect_timeout(mut self, timeout: Duration) -> Self {
         self.connect_timeout = Some(timeout);
         self
@@ -167,7 +167,7 @@ impl ConnectBuilder {
     ///
     /// **Warning**: Modifying transport config may affect the ability
     /// to establish and maintain direct connections. Test carefully.
-    #[must_use] 
+    #[must_use]
     pub fn transport_config(mut self, config: QuicTransportConfig) -> Self {
         self.transport_config = Some(config);
         self
@@ -207,7 +207,7 @@ impl IntoFuture for ConnectBuilder {
 /// # Ok(())
 /// # }
 /// ```
-#[must_use] 
+#[must_use]
 pub fn connect_alpn(
     endpoint: &iroh::Endpoint,
     target: EndpointAddr,

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,6 +31,10 @@ pub enum Error {
     #[error("Connection error: {0}")]
     Connection(String),
 
+    /// Address lookup metadata error.
+    #[error("Address lookup metadata error: {0}")]
+    AddressLookupMetadata(String),
+
     /// DHT discovery error.
     #[cfg(feature = "discovery")]
     #[error("DHT discovery error: {0}")]
@@ -41,6 +45,11 @@ impl Error {
     /// Create a connection error.
     pub fn connection<S: Into<String>>(msg: S) -> Self {
         Self::Connection(msg.into())
+    }
+
+    /// Create an address-lookup metadata error.
+    pub fn address_lookup_metadata<S: Into<String>>(msg: S) -> Self {
+        Self::AddressLookupMetadata(msg.into())
     }
 
     /// Create a DHT discovery error.

--- a/src/server.rs
+++ b/src/server.rs
@@ -4,28 +4,34 @@ use crate::stream::{IrohContext, IrohStream};
 use futures_util::Stream;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio_stream::wrappers::UnboundedReceiverStream;
-use tracing::{debug, error, info};
+use tokio::sync::mpsc::{self, error::TrySendError};
+use tokio_stream::wrappers::ReceiverStream;
+use tracing::{debug, error, info, warn};
+
+pub(crate) const DEFAULT_INCOMING_BUFFER_CAPACITY: usize = 256;
+const OVERLOAD_STREAM_ERROR_CODE: u32 = 1;
 
 /// A simple incoming stream for serving tonic gRPC over iroh connections.
 ///
 /// This follows the same pattern as tonic's UDS example using `serve_with_incoming`.
 pub struct IrohIncoming {
-    receiver: UnboundedReceiverStream<std::result::Result<IrohStream, std::io::Error>>,
+    receiver: ReceiverStream<std::result::Result<IrohStream, std::io::Error>>,
 }
 
 impl IrohIncoming {
     /// Create a new incoming stream from an iroh endpoint.
     ///
-    /// Returns the incoming stream and a sender that the ProtocolHandler should use
+    /// Returns the incoming stream and a sender that the `ProtocolHandler` should use
     /// to send accepted connections.
-    pub fn new() -> (
+    pub fn new(
+        buffer_capacity: usize,
+    ) -> (
         Self,
-        tokio::sync::mpsc::UnboundedSender<std::result::Result<IrohStream, std::io::Error>>,
+        mpsc::Sender<std::result::Result<IrohStream, std::io::Error>>,
     ) {
-        let (tx, rx) = tokio::sync::mpsc::unbounded_channel();
+        let (tx, rx) = mpsc::channel(buffer_capacity);
         let incoming = Self {
-            receiver: UnboundedReceiverStream::new(rx),
+            receiver: ReceiverStream::new(rx),
         };
         (incoming, tx)
     }
@@ -42,16 +48,15 @@ impl Stream for IrohIncoming {
 /// accepts iroh connections and convert them to gRPC streams
 #[derive(Clone, Debug)]
 pub struct GrpcProtocolHandler {
-    pub(crate) sender:
-        tokio::sync::mpsc::UnboundedSender<std::result::Result<IrohStream, std::io::Error>>,
+    pub(crate) sender: mpsc::Sender<std::result::Result<IrohStream, std::io::Error>>,
     service_name: String,
 }
 
 impl GrpcProtocolHandler {
-    /// Create a GrpcProtocolHandler using an existing sender.
+    /// Create a `GrpcProtocolHandler` using an existing sender.
     pub fn with_sender(
         service_name: impl Into<String>,
-        sender: tokio::sync::mpsc::UnboundedSender<std::result::Result<IrohStream, std::io::Error>>,
+        sender: mpsc::Sender<std::result::Result<IrohStream, std::io::Error>>,
     ) -> Self {
         Self {
             sender,
@@ -66,7 +71,6 @@ impl iroh::protocol::ProtocolHandler for GrpcProtocolHandler {
         connection: iroh::endpoint::Connection,
     ) -> impl futures_util::Future<Output = Result<(), iroh::protocol::AcceptError>> + std::marker::Send
     {
-        // Spawn a task to handle this connection's stream
         let sender = self.sender.clone();
         let service_name = self.service_name.clone();
 
@@ -78,15 +82,15 @@ impl iroh::protocol::ProtocolHandler for GrpcProtocolHandler {
                 service_name, remote_node_id
             );
 
-            let service_name_clone = service_name.clone();
-            tokio::spawn(async move {
-                loop {
-                    // Each accept_bi() call represents one gRPC call
-                    match connection.accept_bi().await {
-                        Ok((send, recv)) => {
-                            debug!("Accepted new stream for service '{}'", service_name_clone);
+            loop {
+                // The router already runs each accept future on its own task.
+                // Keeping the stream loop in this future lets router shutdown
+                // own the task lifecycle instead of leaving a detached task behind.
+                if let Ok((mut send, mut recv)) = connection.accept_bi().await {
+                    debug!("Accepted new stream for service '{}'", service_name);
 
-                            // Create IrohStream for this gRPC call
+                    match sender.try_reserve() {
+                        Ok(permit) => {
                             let stream = IrohStream::new(
                                 send,
                                 recv,
@@ -97,29 +101,30 @@ impl iroh::protocol::ProtocolHandler for GrpcProtocolHandler {
                                     alpn: connection.alpn().to_vec(),
                                 },
                             );
-
-                            // Send to tonic's serve_with_incoming (don't wrap in TokioIo)
-                            if let Err(e) = sender.send(Ok(stream)) {
-                                error!(
-                                    "Failed to send stream to handler for service '{}': {}",
-                                    service_name_clone, e
-                                );
-                                break;
-                            }
+                            permit.send(Ok(stream));
                         }
-                        Err(_) => {
-                            // Connection closed or error
-                            debug!("Connection closed for service '{}'", service_name_clone);
+                        Err(TrySendError::Full(())) => {
+                            warn!(
+                                "Dropping overloaded stream for service '{}' from peer: {}",
+                                service_name, remote_node_id
+                            );
+                            reject_stream(&mut send, &mut recv);
+                        }
+                        Err(TrySendError::Closed(())) => {
+                            error!(
+                                "Failed to forward stream to handler for service '{}': channel closed",
+                                service_name
+                            );
+                            reject_stream(&mut send, &mut recv);
                             break;
                         }
                     }
+                } else {
+                    // Connection closed or error
+                    debug!("Connection closed for service '{}'", service_name);
+                    break;
                 }
-            });
-
-            debug!(
-                "Successfully set up stream handler for service '{}' from peer: {}",
-                service_name, remote_node_id
-            );
+            }
 
             Ok::<(), iroh::protocol::AcceptError>(())
         }
@@ -132,10 +137,15 @@ impl iroh::protocol::ProtocolHandler for GrpcProtocolHandler {
                 "Shutting down gRPC protocol handler for service: {}",
                 service_name
             );
-            // The spawned tasks will end when the connection closes
-            // The incoming stream will end when the sender is dropped
+            // Active connection handlers are owned by the router because accept()
+            // keeps the per-connection loop inside the router-managed future.
         }
     }
+}
+
+fn reject_stream(send: &mut iroh::endpoint::SendStream, recv: &mut iroh::endpoint::RecvStream) {
+    let _ = recv.stop(OVERLOAD_STREAM_ERROR_CODE.into());
+    let _ = send.reset(OVERLOAD_STREAM_ERROR_CODE.into());
 }
 
 #[cfg(test)]
@@ -146,15 +156,28 @@ mod tests {
 
     #[tokio::test]
     async fn test_with_sender_uses_existing_channel() {
-        let (mut incoming, sender) = IrohIncoming::new();
+        let (mut incoming, sender) = IrohIncoming::new(1);
         let _handler = GrpcProtocolHandler::with_sender("shared-service", sender.clone());
 
         // Send an error through the shared sender and verify the incoming stream receives it.
         sender
-            .send(Err(io::Error::new(io::ErrorKind::Other, "boom")))
+            .send(Err(io::Error::other("boom")))
+            .await
             .expect("send should succeed");
 
         let next = incoming.next().await.expect("stream should yield");
         assert!(next.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_incoming_channel_is_bounded() {
+        let (_incoming, sender) = IrohIncoming::new(1);
+
+        sender
+            .try_send(Err(io::Error::other("first")))
+            .expect("first send should fit in bounded queue");
+
+        let second = sender.try_send(Err(io::Error::other("second")));
+        assert!(matches!(second, Err(TrySendError::Full(_))));
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -9,7 +9,7 @@ use std::time::Instant;
 use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
 use tonic::transport::server::Connected;
 
-/// Convert a QUIC write error to an appropriate io::Error.
+/// Convert a QUIC write error to an appropriate `io::Error`.
 fn write_error_to_io(e: WriteError) -> std::io::Error {
     let kind = match &e {
         WriteError::Stopped(_) => ErrorKind::BrokenPipe,
@@ -44,7 +44,8 @@ pub struct IrohStream {
 impl Unpin for IrohStream {}
 
 impl IrohStream {
-    /// Creates a new IrohStream from send/recv streams and context
+    /// Creates a new `IrohStream` from send/recv streams and context
+    #[must_use] 
     pub fn new(
         send: iroh::endpoint::SendStream,
         recv: iroh::endpoint::RecvStream,

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -45,7 +45,7 @@ impl Unpin for IrohStream {}
 
 impl IrohStream {
     /// Creates a new `IrohStream` from send/recv streams and context
-    #[must_use] 
+    #[must_use]
     pub fn new(
         send: iroh::endpoint::SendStream,
         recv: iroh::endpoint::RecvStream,

--- a/src/swarm/dht/backend.rs
+++ b/src/swarm/dht/backend.rs
@@ -23,6 +23,10 @@ pub struct DhtBackend {
 
 impl DhtBackend {
     /// Create a new DHT backend, starting a DHT client.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the DHT client fails to bind.
     pub fn new(endpoint: &Endpoint) -> std::io::Result<Self> {
         let dht =
             Arc::new(Dht::client().map_err(|e| std::io::Error::other(format!("DHT client: {e}")))?);
@@ -37,6 +41,7 @@ impl DhtBackend {
     }
 
     /// Create a DHT backend with an existing DHT client.
+    #[must_use] 
     pub fn with_dht(endpoint: &Endpoint, dht: Arc<Dht>) -> Self {
         Self {
             endpoint: endpoint.clone(),
@@ -49,39 +54,45 @@ impl DhtBackend {
     }
 
     /// Set the feed priority (lower = polled first). Default: 100.
+    #[must_use] 
     pub fn priority(mut self, p: u8) -> Self {
         self.priority = p;
         self
     }
 
     /// Set the source trust level (0-255). Default: 50.
+    #[must_use] 
     pub fn trust(mut self, t: u8) -> Self {
         self.trust = t;
         self
     }
 
     /// Set the DHT poll interval. Default: 60s.
+    #[must_use] 
     pub fn poll_interval(mut self, d: Duration) -> Self {
         self.poll_interval = d;
         self
     }
 
     /// Set required tags for filtering DHT records.
+    #[must_use] 
     pub fn required_tags(mut self, tags: Vec<String>) -> Self {
         self.required_tags = tags;
         self
     }
 
     /// Access the underlying DHT client.
+    #[must_use] 
     pub fn dht(&self) -> &Arc<Dht> {
         &self.dht
     }
 
     /// Create a DHT publisher for server-side announcements.
+    #[must_use] 
     pub fn create_publisher(&self, config: DhtPublisherConfig) -> DhtPublisher {
         DhtPublisher::new(
             Arc::clone(&self.dht),
-            *self.endpoint.id().as_bytes(),
+            self.endpoint.secret_key().clone(),
             config,
         )
     }

--- a/src/swarm/dht/backend.rs
+++ b/src/swarm/dht/backend.rs
@@ -41,7 +41,7 @@ impl DhtBackend {
     }
 
     /// Create a DHT backend with an existing DHT client.
-    #[must_use] 
+    #[must_use]
     pub fn with_dht(endpoint: &Endpoint, dht: Arc<Dht>) -> Self {
         Self {
             endpoint: endpoint.clone(),
@@ -54,41 +54,41 @@ impl DhtBackend {
     }
 
     /// Set the feed priority (lower = polled first). Default: 100.
-    #[must_use] 
+    #[must_use]
     pub fn priority(mut self, p: u8) -> Self {
         self.priority = p;
         self
     }
 
     /// Set the source trust level (0-255). Default: 50.
-    #[must_use] 
+    #[must_use]
     pub fn trust(mut self, t: u8) -> Self {
         self.trust = t;
         self
     }
 
     /// Set the DHT poll interval. Default: 60s.
-    #[must_use] 
+    #[must_use]
     pub fn poll_interval(mut self, d: Duration) -> Self {
         self.poll_interval = d;
         self
     }
 
     /// Set required tags for filtering DHT records.
-    #[must_use] 
+    #[must_use]
     pub fn required_tags(mut self, tags: Vec<String>) -> Self {
         self.required_tags = tags;
         self
     }
 
     /// Access the underlying DHT client.
-    #[must_use] 
+    #[must_use]
     pub fn dht(&self) -> &Arc<Dht> {
         &self.dht
     }
 
     /// Create a DHT publisher for server-side announcements.
-    #[must_use] 
+    #[must_use]
     pub fn create_publisher(&self, config: DhtPublisherConfig) -> DhtPublisher {
         DhtPublisher::new(
             Arc::clone(&self.dht),

--- a/src/swarm/dht/mod.rs
+++ b/src/swarm/dht/mod.rs
@@ -1,4 +1,12 @@
 //! DHT helpers and types used by swarm discovery.
+//!
+//! Threat model:
+//! - DHT service advertisements are signed by the advertising iroh node identity,
+//!   so a peer cannot forge another node's ad.
+//! - The shared shard buckets themselves remain globally writable rendezvous
+//!   points. Attackers can still spam or overwrite shard contents.
+//! - This backend is intended for bootstrap only. Once an honest peer is found,
+//!   direct iroh communication becomes the trusted path.
 
 pub mod backend;
 pub mod publisher;
@@ -6,32 +14,87 @@ pub mod resolver;
 
 use sha2::{Digest, Sha256};
 
-/// Derive signing keypair from service ALPN and unix minute.
-pub fn derive_signing_key(alpn: &[u8], unix_minute: u64) -> mainline::SigningKey {
+pub(crate) const DHT_SHARD_COUNT: u8 = 16;
+pub(crate) const DHT_REPLICA_COUNT: usize = 2;
+pub(crate) const DHT_PUBLISH_RETRIES: usize = 4;
+pub(crate) const DHT_AD_TTL_SECS: u64 = 120;
+pub(crate) const DHT_QUERY_CONCURRENCY: usize = 4;
+
+/// Derive the shared shard signing key from service ALPN, unix minute, and shard index.
+#[must_use] 
+pub fn derive_signing_key(alpn: &[u8], unix_minute: u64, shard: u8) -> mainline::SigningKey {
     let mut hasher = Sha256::new();
-    hasher.update(b"tonic-iroh-transport:v1:");
+    hasher.update(b"tonic-iroh-transport:dht:key:v2:");
     hasher.update(alpn);
     hasher.update(unix_minute.to_le_bytes());
+    hasher.update([shard]);
     let hash = hasher.finalize();
     mainline::SigningKey::from_bytes(&hash.into())
 }
 
-/// Derive salt for DHT mutable item.
-pub fn derive_salt(alpn: &[u8], unix_minute: u64) -> Vec<u8> {
+/// Derive salt for a service shard bucket.
+#[must_use] 
+pub fn derive_salt(alpn: &[u8], unix_minute: u64, shard: u8) -> Vec<u8> {
     let mut hasher = Sha256::new();
-    hasher.update(b"tonic-iroh-transport:salt:v1:");
+    hasher.update(b"tonic-iroh-transport:dht:salt:v2:");
     hasher.update(alpn);
     hasher.update(unix_minute.to_le_bytes());
+    hasher.update([shard]);
     hasher.finalize().to_vec()
 }
 
+/// Deterministically choose the shards this node should publish into for a service.
+#[must_use] 
+pub fn replica_shards(node_id: &[u8; 32], alpn: &[u8]) -> Vec<u8> {
+    replica_shards_with_limits(node_id, alpn, DHT_SHARD_COUNT, DHT_REPLICA_COUNT)
+}
+
 /// Get current unix minute with optional offset.
+///
+/// # Panics
+///
+/// Panics if the system clock is before the Unix epoch.
+#[must_use]
 pub fn unix_minute(offset: i64) -> u64 {
     let now = std::time::SystemTime::now()
         .duration_since(std::time::UNIX_EPOCH)
         .unwrap()
         .as_secs();
-    ((now / 60) as i64 + offset) as u64
+    apply_minute_offset(now / 60, offset)
+}
+
+fn apply_minute_offset(minute: u64, offset: i64) -> u64 {
+    if offset >= 0 {
+        minute.saturating_add(offset.unsigned_abs())
+    } else {
+        minute.saturating_sub(offset.unsigned_abs())
+    }
+}
+
+fn replica_shards_with_limits(
+    node_id: &[u8; 32],
+    alpn: &[u8],
+    shard_count: u8,
+    replica_count: usize,
+) -> Vec<u8> {
+    let replica_count = replica_count.min(shard_count as usize);
+    let mut ranked_shards = (0..shard_count)
+        .map(|shard| {
+            let mut hasher = Sha256::new();
+            hasher.update(b"tonic-iroh-transport:dht:shards:v3:");
+            hasher.update(node_id);
+            hasher.update(alpn);
+            hasher.update([shard]);
+            (hasher.finalize(), shard)
+        })
+        .collect::<Vec<_>>();
+
+    ranked_shards.sort_by(|left, right| left.0.cmp(&right.0).then_with(|| left.1.cmp(&right.1)));
+    ranked_shards
+        .into_iter()
+        .take(replica_count)
+        .map(|(_, shard)| shard)
+        .collect()
 }
 
 #[cfg(test)]
@@ -43,24 +106,24 @@ mod tests {
         let alpn = b"/test.Service/1.0";
         let minute = 12345u64;
 
-        let key1 = derive_signing_key(alpn, minute);
-        let key2 = derive_signing_key(alpn, minute);
+        let key1 = derive_signing_key(alpn, minute, 3);
+        let key2 = derive_signing_key(alpn, minute, 3);
         assert_eq!(key1.to_bytes(), key2.to_bytes());
     }
 
     #[test]
     fn signing_key_changes_with_minute() {
         let alpn = b"/test.Service/1.0";
-        let key1 = derive_signing_key(alpn, 12345);
-        let key2 = derive_signing_key(alpn, 12346);
+        let key1 = derive_signing_key(alpn, 12345, 3);
+        let key2 = derive_signing_key(alpn, 12346, 3);
         assert_ne!(key1.to_bytes(), key2.to_bytes());
     }
 
     #[test]
     fn signing_key_changes_with_service() {
         let minute = 12345u64;
-        let key1 = derive_signing_key(b"/service.A/1.0", minute);
-        let key2 = derive_signing_key(b"/service.B/1.0", minute);
+        let key1 = derive_signing_key(b"/service.A/1.0", minute, 3);
+        let key2 = derive_signing_key(b"/service.B/1.0", minute, 3);
         assert_ne!(key1.to_bytes(), key2.to_bytes());
     }
 
@@ -69,10 +132,42 @@ mod tests {
         let alpn = b"/test.Service/1.0";
         let minute = 12345u64;
 
-        let salt1 = derive_salt(alpn, minute);
-        let salt2 = derive_salt(alpn, minute);
+        let salt1 = derive_salt(alpn, minute, 3);
+        let salt2 = derive_salt(alpn, minute, 3);
         assert_eq!(salt1, salt2);
         assert_eq!(salt1.len(), 32);
+    }
+
+    #[test]
+    fn shard_selection_is_stable_and_distinct() {
+        let node_id = [42u8; 32];
+        let shards = replica_shards(&node_id, b"/test.Service/1.0");
+
+        assert_eq!(shards.len(), DHT_REPLICA_COUNT);
+        assert_eq!(shards, replica_shards(&node_id, b"/test.Service/1.0"));
+        assert_ne!(shards[0], shards[1]);
+        assert!(shards.iter().all(|shard| *shard < DHT_SHARD_COUNT));
+    }
+
+    #[test]
+    fn shard_selection_caps_replica_count_to_available_shards() {
+        let node_id = [7u8; 32];
+        let shards = replica_shards_with_limits(&node_id, b"/test.Service/1.0", 3, 8);
+
+        assert_eq!(shards.len(), 3);
+        assert_eq!(
+            shards,
+            replica_shards_with_limits(&node_id, b"/test.Service/1.0", 3, 8)
+        );
+        assert_eq!(
+            shards
+                .iter()
+                .copied()
+                .collect::<std::collections::BTreeSet<_>>()
+                .len(),
+            3
+        );
+        assert!(shards.iter().all(|shard| *shard < 3));
     }
 
     #[test]
@@ -82,5 +177,12 @@ mod tests {
         let next = unix_minute(1);
         assert_eq!(previous + 1, current);
         assert_eq!(current + 1, next);
+    }
+
+    #[test]
+    fn negative_minute_offset_saturates_at_zero() {
+        assert_eq!(apply_minute_offset(0, -1), 0);
+        assert_eq!(apply_minute_offset(0, i64::MIN), 0);
+        assert_eq!(apply_minute_offset(3, -10), 0);
     }
 }

--- a/src/swarm/dht/mod.rs
+++ b/src/swarm/dht/mod.rs
@@ -21,7 +21,7 @@ pub(crate) const DHT_AD_TTL_SECS: u64 = 120;
 pub(crate) const DHT_QUERY_CONCURRENCY: usize = 4;
 
 /// Derive the shared shard signing key from service ALPN, unix minute, and shard index.
-#[must_use] 
+#[must_use]
 pub fn derive_signing_key(alpn: &[u8], unix_minute: u64, shard: u8) -> mainline::SigningKey {
     let mut hasher = Sha256::new();
     hasher.update(b"tonic-iroh-transport:dht:key:v2:");
@@ -33,7 +33,7 @@ pub fn derive_signing_key(alpn: &[u8], unix_minute: u64, shard: u8) -> mainline:
 }
 
 /// Derive salt for a service shard bucket.
-#[must_use] 
+#[must_use]
 pub fn derive_salt(alpn: &[u8], unix_minute: u64, shard: u8) -> Vec<u8> {
     let mut hasher = Sha256::new();
     hasher.update(b"tonic-iroh-transport:dht:salt:v2:");
@@ -44,7 +44,7 @@ pub fn derive_salt(alpn: &[u8], unix_minute: u64, shard: u8) -> Vec<u8> {
 }
 
 /// Deterministically choose the shards this node should publish into for a service.
-#[must_use] 
+#[must_use]
 pub fn replica_shards(node_id: &[u8; 32], alpn: &[u8]) -> Vec<u8> {
     replica_shards_with_limits(node_id, alpn, DHT_SHARD_COUNT, DHT_REPLICA_COUNT)
 }

--- a/src/swarm/dht/publisher.rs
+++ b/src/swarm/dht/publisher.rs
@@ -41,7 +41,7 @@ pub struct DhtPublisher {
 
 impl DhtPublisher {
     /// Create a publisher for a given DHT client and node ID.
-    #[must_use] 
+    #[must_use]
     pub fn new(dht: Arc<Dht>, secret_key: SecretKey, config: DhtPublisherConfig) -> Self {
         Self {
             dht,

--- a/src/swarm/dht/publisher.rs
+++ b/src/swarm/dht/publisher.rs
@@ -3,13 +3,15 @@
 use std::sync::Arc;
 use std::time::Duration;
 
-use mainline::{Dht, MutableItem};
+use iroh::SecretKey;
+use mainline::{errors::PutMutableError, Dht, MutableItem};
 use tokio::sync::broadcast;
-use tokio::task::JoinHandle;
 use tracing::{debug, error, info, warn};
 
-use super::{derive_salt, derive_signing_key, unix_minute};
-use crate::swarm::record::ServiceRecord;
+use super::{
+    derive_salt, derive_signing_key, replica_shards, DHT_AD_TTL_SECS, DHT_PUBLISH_RETRIES,
+};
+use crate::swarm::record::{ServiceBucket, SignedServiceAd};
 
 /// Configuration for DHT publishing.
 #[derive(Debug, Clone)]
@@ -32,21 +34,20 @@ impl Default for DhtPublisherConfig {
 /// Publishes service records to the DHT on a fixed interval.
 pub struct DhtPublisher {
     dht: Arc<Dht>,
-    node_id: [u8; 32],
+    secret_key: SecretKey,
     services: Vec<Vec<u8>>,
     config: DhtPublisherConfig,
-    task_handle: Option<JoinHandle<()>>,
 }
 
 impl DhtPublisher {
     /// Create a publisher for a given DHT client and node ID.
-    pub fn new(dht: Arc<Dht>, node_id: [u8; 32], config: DhtPublisherConfig) -> Self {
+    #[must_use] 
+    pub fn new(dht: Arc<Dht>, secret_key: SecretKey, config: DhtPublisherConfig) -> Self {
         Self {
             dht,
-            node_id,
+            secret_key,
             services: Vec::new(),
             config,
-            task_handle: None,
         }
     }
 
@@ -55,50 +56,32 @@ impl DhtPublisher {
         self.services.push(alpn);
     }
 
-    /// Start the background publishing task.
-    pub fn start(&mut self, mut shutdown_rx: broadcast::Receiver<()>) {
-        if self.task_handle.is_some() {
-            warn!("DHT publisher already started");
-            return;
-        }
+    /// Run the background publishing loop until shutdown is signalled.
+    pub async fn run(self, mut shutdown_rx: broadcast::Receiver<()>) {
+        let Self {
+            dht,
+            secret_key,
+            services,
+            config,
+        } = self;
 
-        let dht = Arc::clone(&self.dht);
-        let services = self.services.clone();
-        let node_id = self.node_id;
-        let config = self.config.clone();
+        info!(services = services.len(), "Starting DHT publisher");
+        publish_all(&dht, &services, &secret_key, &config.tags).await;
 
-        let handle = tokio::spawn(async move {
-            info!(services = services.len(), "Starting DHT publisher");
-            let mut seq = 0i64;
+        let mut interval = tokio::time::interval(config.publish_interval);
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        let _ = interval.tick().await;
 
-            publish_all(&dht, &services, node_id, &config.tags, seq).await;
-            seq += 1;
-
-            let mut interval = tokio::time::interval(config.publish_interval);
-            interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-
-            loop {
-                tokio::select! {
-                    _ = interval.tick() => {
-                        publish_all(&dht, &services, node_id, &config.tags, seq).await;
-                        seq += 1;
-                    }
-                    _ = shutdown_rx.recv() => {
-                        info!("DHT publisher shutting down");
-                        break;
-                    }
+        loop {
+            tokio::select! {
+                _ = interval.tick() => {
+                    publish_all(&dht, &services, &secret_key, &config.tags).await;
+                }
+                _ = shutdown_rx.recv() => {
+                    info!("DHT publisher shutting down");
+                    break;
                 }
             }
-        });
-
-        self.task_handle = Some(handle);
-    }
-
-    /// Stop the background task.
-    pub async fn stop(&mut self) {
-        if let Some(handle) = self.task_handle.take() {
-            handle.abort();
-            let _ = handle.await;
         }
     }
 }
@@ -106,32 +89,135 @@ impl DhtPublisher {
 async fn publish_all(
     dht: &Arc<Dht>,
     services: &[Vec<u8>],
-    node_id: [u8; 32],
+    secret_key: &SecretKey,
     tags: &[String],
-    seq: i64,
 ) {
-    let minute = unix_minute(0);
-    let record = ServiceRecord {
-        node_id,
-        tags: tags.to_vec(),
-        published_at: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap_or_default()
-            .as_secs(),
-    };
-    let value = postcard::to_allocvec(&record).expect("serialization should not fail");
-
+    let node_id = secret_key.public();
     for alpn in services {
-        let signing_key = derive_signing_key(alpn, minute);
-        let salt = derive_salt(alpn, minute);
-        let item = MutableItem::new(signing_key, &value, seq, Some(&salt));
-
-        let dht = Arc::clone(dht);
         let alpn_display = String::from_utf8_lossy(alpn).to_string();
-        match tokio::task::spawn_blocking(move || dht.put_mutable(item, None)).await {
-            Ok(Ok(_)) => debug!(alpn = %alpn_display, seq, minute, "Published DHT record"),
-            Ok(Err(e)) => error!(alpn = %alpn_display, error = %e, "Failed to publish DHT record"),
-            Err(e) => error!(alpn = %alpn_display, error = %e, "DHT publish task panicked"),
+
+        for shard in replica_shards(node_id.as_bytes(), alpn) {
+            match publish_shard(dht, secret_key, alpn, shard, tags).await {
+                Ok(()) => debug!(alpn = %alpn_display, shard, "Published DHT shard"),
+                Err(e) => {
+                    warn!(alpn = %alpn_display, shard, error = %e, "Failed to publish DHT shard");
+                }
+            }
         }
     }
+}
+
+async fn publish_shard(
+    dht: &Arc<Dht>,
+    secret_key: &SecretKey,
+    alpn: &[u8],
+    shard: u8,
+    tags: &[String],
+) -> Result<(), String> {
+    let published_at = unix_timestamp_secs()?;
+    let minute = published_at / 60;
+    let expires_at = published_at.saturating_add(DHT_AD_TTL_SECS);
+    let local_ad = SignedServiceAd::sign(
+        secret_key,
+        alpn,
+        minute,
+        shard,
+        tags,
+        published_at,
+        expires_at,
+    )
+    .map_err(|e| format!("sign service ad: {e}"))?;
+    let preferred_node = local_ad.node_id();
+
+    for attempt in 0..DHT_PUBLISH_RETRIES {
+        let (ads, latest_seq) = read_shard_state(dht, alpn, minute, shard, published_at).await;
+        let mut bucket = ServiceBucket::new(ads);
+        bucket.upsert(local_ad.clone());
+
+        let fits = bucket
+            .trim_to_size(Some(preferred_node))
+            .map_err(|e| format!("serialize service bucket: {e}"))?;
+        if !fits {
+            return Err("local service advertisement exceeds shard bucket size".to_string());
+        }
+
+        let value = postcard::to_allocvec(&bucket)
+            .map_err(|e| format!("serialize trimmed service bucket: {e}"))?;
+        let signing_key = derive_signing_key(alpn, minute, shard);
+        let salt = derive_salt(alpn, minute, shard);
+        let item = MutableItem::new(
+            signing_key,
+            &value,
+            latest_seq.map_or(1, |seq| seq + 1),
+            Some(&salt),
+        );
+
+        let dht = Arc::clone(dht);
+        let put_result = tokio::task::spawn_blocking(move || dht.put_mutable(item, latest_seq))
+            .await
+            .map_err(|e| format!("publish task panicked: {e}"))?;
+
+        match put_result {
+            Ok(_) => return Ok(()),
+            Err(PutMutableError::Concurrency(err)) => {
+                debug!(attempt, shard, error = %err, "Retrying DHT shard publish after contention");
+            }
+            Err(PutMutableError::Query(err)) => {
+                return Err(format!("put mutable shard: {err}"));
+            }
+        }
+    }
+
+    Err("DHT shard remained contended after retries".to_string())
+}
+
+async fn read_shard_state(
+    dht: &Arc<Dht>,
+    alpn: &[u8],
+    minute: u64,
+    shard: u8,
+    now: u64,
+) -> (Vec<SignedServiceAd>, Option<i64>) {
+    let signing_key = derive_signing_key(alpn, minute, shard);
+    let public_key = *signing_key.verifying_key().as_bytes();
+    let salt = derive_salt(alpn, minute, shard);
+    let dht = Arc::clone(dht);
+    let alpn_display = String::from_utf8_lossy(alpn).to_string();
+
+    let items = match tokio::task::spawn_blocking(move || {
+        dht.get_mutable(&public_key, Some(salt.as_slice()), None)
+            .collect::<Vec<_>>()
+    })
+    .await
+    {
+        Ok(items) => items,
+        Err(e) => {
+            error!(alpn = %alpn_display, shard, error = %e, "DHT shard read task panicked");
+            return (Vec::new(), None);
+        }
+    };
+
+    let latest_seq = items.iter().map(mainline::MutableItem::seq).max();
+    let buckets = items
+        .into_iter()
+        .filter_map(|item| match postcard::from_bytes::<ServiceBucket>(item.value()) {
+            Ok(bucket) => Some(bucket),
+            Err(e) => {
+                warn!(alpn = %alpn_display, shard, error = %e, "Failed to decode DHT shard bucket");
+                None
+            }
+        })
+        .collect::<Vec<_>>();
+
+    (
+        ServiceBucket::merge_valid(buckets, alpn, minute, shard, now),
+        latest_seq,
+    )
+}
+
+fn unix_timestamp_secs() -> Result<u64, String> {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|duration| duration.as_secs())
+        .map_err(|e| format!("system clock before unix epoch: {e}"))
 }

--- a/src/swarm/dht/resolver.rs
+++ b/src/swarm/dht/resolver.rs
@@ -18,7 +18,7 @@ pub struct DhtResolver {
 
 impl DhtResolver {
     /// Create a new resolver wrapping a shared DHT client.
-    #[must_use] 
+    #[must_use]
     pub fn new(dht: Arc<Dht>) -> Self {
         Self { dht }
     }

--- a/src/swarm/dht/resolver.rs
+++ b/src/swarm/dht/resolver.rs
@@ -5,7 +5,8 @@ use std::sync::Arc;
 use mainline::Dht;
 use tracing::{debug, trace, warn};
 
-use crate::swarm::record::ServiceRecord;
+use crate::swarm::record::{ServiceBucket, SignedServiceAd};
+use crate::{Error, Result};
 
 use super::{derive_salt, derive_signing_key};
 
@@ -17,43 +18,80 @@ pub struct DhtResolver {
 
 impl DhtResolver {
     /// Create a new resolver wrapping a shared DHT client.
+    #[must_use] 
     pub fn new(dht: Arc<Dht>) -> Self {
         Self { dht }
     }
 
-    /// Query a specific minute slot for a service ALPN.
-    pub async fn query_minute(&self, alpn: &[u8], minute: u64) -> Option<ServiceRecord> {
-        let signing_key = derive_signing_key(alpn, minute);
+    /// Query a specific shard bucket for a service ALPN and minute.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the DHT query task panics.
+    pub async fn query_shard(
+        &self,
+        alpn: &[u8],
+        minute: u64,
+        shard: u8,
+    ) -> Result<Vec<SignedServiceAd>> {
+        let signing_key = derive_signing_key(alpn, minute, shard);
         let public_key = signing_key.verifying_key();
         let pk_bytes = *public_key.as_bytes();
-        let salt = derive_salt(alpn, minute);
+        let salt = derive_salt(alpn, minute, shard);
         let dht = Arc::clone(&self.dht);
         let alpn_owned = alpn.to_vec();
 
-        trace!(alpn = %String::from_utf8_lossy(&alpn_owned), minute, "Querying DHT");
+        trace!(
+            alpn = %String::from_utf8_lossy(&alpn_owned),
+            minute,
+            shard,
+            "Querying DHT shard"
+        );
 
         let result = tokio::task::spawn_blocking(move || {
-            dht.get_mutable_most_recent(&pk_bytes, Some(&salt))
+            dht.get_mutable(&pk_bytes, Some(salt.as_slice()), None)
+                .collect::<Vec<_>>()
         })
         .await
-        .ok()
-        .flatten();
+        .map_err(|e| {
+            Error::dht_discovery(format!(
+                "DHT shard query task failed for alpn={} minute={minute} shard={shard}: {e}",
+                String::from_utf8_lossy(&alpn_owned)
+            ))
+        })?;
 
-        match result {
-            Some(item) => match postcard::from_bytes::<ServiceRecord>(item.value()) {
-                Ok(record) => {
-                    debug!(alpn = %String::from_utf8_lossy(&alpn_owned), minute, "Found DHT record");
-                    Some(record)
-                }
-                Err(e) => {
-                    warn!(alpn = %String::from_utf8_lossy(&alpn_owned), error = %e, "Failed to deserialize DHT record");
-                    None
-                }
-            },
-            None => {
-                trace!(alpn = %String::from_utf8_lossy(&alpn_owned), minute, "No DHT record found");
-                None
-            }
-        }
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs();
+
+        let buckets = result
+            .into_iter()
+            .filter_map(
+                |item| match postcard::from_bytes::<ServiceBucket>(item.value()) {
+                    Ok(bucket) => Some(bucket),
+                    Err(e) => {
+                        warn!(
+                            alpn = %String::from_utf8_lossy(&alpn_owned),
+                            minute,
+                            shard,
+                            error = %e,
+                            "Failed to deserialize DHT shard bucket"
+                        );
+                        None
+                    }
+                },
+            )
+            .collect::<Vec<_>>();
+
+        let ads = ServiceBucket::merge_valid(buckets, &alpn_owned, minute, shard, now);
+        debug!(
+            alpn = %String::from_utf8_lossy(&alpn_owned),
+            minute,
+            shard,
+            ads = ads.len(),
+            "Resolved DHT shard"
+        );
+        Ok(ads)
     }
 }

--- a/src/swarm/discovery.rs
+++ b/src/swarm/discovery.rs
@@ -37,31 +37,31 @@ impl Peer {
     }
 
     /// The peer's endpoint identifier.
-    #[must_use] 
+    #[must_use]
     pub fn id(&self) -> EndpointId {
         self.id
     }
 
     /// Effective trust: `min(remote_trust, source_trust)`.
-    #[must_use] 
+    #[must_use]
     pub fn trust(&self) -> u8 {
         self.remote_trust.min(self.source_trust)
     }
 
     /// Name of the discovery source that found this peer.
-    #[must_use] 
+    #[must_use]
     pub fn source(&self) -> &str {
         self.source
     }
 
     /// Raw peer-level trust before source adjustment.
-    #[must_use] 
+    #[must_use]
     pub fn remote_trust(&self) -> u8 {
         self.remote_trust
     }
 
     /// Trust level of the source/producer that discovered this peer.
-    #[must_use] 
+    #[must_use]
     pub fn source_trust(&self) -> u8 {
         self.source_trust
     }
@@ -98,7 +98,7 @@ pub struct MdnsBackend {
 
 impl MdnsBackend {
     /// Create an mDNS backend wrapping the given discovery instance.
-    #[must_use] 
+    #[must_use]
     pub fn new(mdns: MdnsAddressLookup) -> Self {
         Self {
             mdns: Arc::new(mdns),
@@ -108,14 +108,14 @@ impl MdnsBackend {
     }
 
     /// Set the feed priority (lower = polled first). Default: 50.
-    #[must_use] 
+    #[must_use]
     pub fn priority(mut self, p: u8) -> Self {
         self.priority = p;
         self
     }
 
     /// Set the source trust level (0-255). Default: 200.
-    #[must_use] 
+    #[must_use]
     pub fn trust(mut self, t: u8) -> Self {
         self.trust = t;
         self
@@ -154,7 +154,7 @@ pub struct StaticBackend {
 
 impl StaticBackend {
     /// Create an empty static backend.
-    #[must_use] 
+    #[must_use]
     pub fn new() -> Self {
         Self { specs: Vec::new() }
     }
@@ -212,7 +212,7 @@ pub struct PeerExchangeBackend {
 
 impl PeerExchangeBackend {
     /// Create a new peer-exchange backend.
-    #[must_use] 
+    #[must_use]
     pub fn new() -> Self {
         let (tx, _) = broadcast::channel(128);
         Self {
@@ -223,14 +223,14 @@ impl PeerExchangeBackend {
     }
 
     /// Set the feed priority (lower = polled first). Default: 110.
-    #[must_use] 
+    #[must_use]
     pub fn priority(mut self, p: u8) -> Self {
         self.priority = p;
         self
     }
 
     /// Set the source trust level (0-255). Default: 100.
-    #[must_use] 
+    #[must_use]
     pub fn trust(mut self, t: u8) -> Self {
         self.trust = t;
         self

--- a/src/swarm/discovery.rs
+++ b/src/swarm/discovery.rs
@@ -22,41 +22,46 @@ pub struct DiscoveredPeer {
 pub struct Peer {
     id: EndpointId,
     source: &'static str,
-    peer_trust: u8,
+    remote_trust: u8,
     source_trust: u8,
 }
 
 impl Peer {
-    pub(crate) fn new(discovered: DiscoveredPeer, source: &'static str, source_trust: u8) -> Self {
+    pub(crate) fn new(discovered: &DiscoveredPeer, source: &'static str, source_trust: u8) -> Self {
         Self {
             id: discovered.id,
             source,
-            peer_trust: discovered.trust,
+            remote_trust: discovered.trust,
             source_trust,
         }
     }
 
     /// The peer's endpoint identifier.
+    #[must_use] 
     pub fn id(&self) -> EndpointId {
         self.id
     }
 
-    /// Effective trust: min(peer_trust, source_trust).
+    /// Effective trust: `min(remote_trust, source_trust)`.
+    #[must_use] 
     pub fn trust(&self) -> u8 {
-        self.peer_trust.min(self.source_trust)
+        self.remote_trust.min(self.source_trust)
     }
 
     /// Name of the discovery source that found this peer.
+    #[must_use] 
     pub fn source(&self) -> &str {
         self.source
     }
 
     /// Raw peer-level trust before source adjustment.
-    pub fn peer_trust(&self) -> u8 {
-        self.peer_trust
+    #[must_use] 
+    pub fn remote_trust(&self) -> u8 {
+        self.remote_trust
     }
 
     /// Trust level of the source/producer that discovered this peer.
+    #[must_use] 
     pub fn source_trust(&self) -> u8 {
         self.source_trust
     }
@@ -93,6 +98,7 @@ pub struct MdnsBackend {
 
 impl MdnsBackend {
     /// Create an mDNS backend wrapping the given discovery instance.
+    #[must_use] 
     pub fn new(mdns: MdnsAddressLookup) -> Self {
         Self {
             mdns: Arc::new(mdns),
@@ -102,12 +108,14 @@ impl MdnsBackend {
     }
 
     /// Set the feed priority (lower = polled first). Default: 50.
+    #[must_use] 
     pub fn priority(mut self, p: u8) -> Self {
         self.priority = p;
         self
     }
 
     /// Set the source trust level (0-255). Default: 200.
+    #[must_use] 
     pub fn trust(mut self, t: u8) -> Self {
         self.trust = t;
         self
@@ -146,11 +154,13 @@ pub struct StaticBackend {
 
 impl StaticBackend {
     /// Create an empty static backend.
+    #[must_use] 
     pub fn new() -> Self {
         Self { specs: Vec::new() }
     }
 
     /// Add a group of static peers.
+    #[must_use]
     pub fn add_peers<I>(mut self, scope: Scope, priority: u8, trust: u8, peers: I) -> Self
     where
         I: IntoIterator<Item = EndpointId>,
@@ -202,6 +212,7 @@ pub struct PeerExchangeBackend {
 
 impl PeerExchangeBackend {
     /// Create a new peer-exchange backend.
+    #[must_use] 
     pub fn new() -> Self {
         let (tx, _) = broadcast::channel(128);
         Self {
@@ -212,12 +223,14 @@ impl PeerExchangeBackend {
     }
 
     /// Set the feed priority (lower = polled first). Default: 110.
+    #[must_use] 
     pub fn priority(mut self, p: u8) -> Self {
         self.priority = p;
         self
     }
 
     /// Set the source trust level (0-255). Default: 100.
+    #[must_use] 
     pub fn trust(mut self, t: u8) -> Self {
         self.trust = t;
         self

--- a/src/swarm/engine.rs
+++ b/src/swarm/engine.rs
@@ -12,7 +12,7 @@ use crate::Result;
 use super::discovery::Peer;
 use super::peers::{scope_matches, PeerFeed, PeerFeedSpec};
 
-/// A tagged feed: wraps a PeerFeed to attach source metadata to each item.
+/// A tagged feed: wraps a `PeerFeed` to attach source metadata to each item.
 struct TaggedFeed {
     name: &'static str,
     trust: u8,
@@ -26,7 +26,7 @@ impl Stream for TaggedFeed {
         let this = self.get_mut();
         match Pin::new(&mut this.inner).poll_next(cx) {
             Poll::Ready(Some(Ok(discovered))) => {
-                let peer = Peer::new(discovered, this.name, this.trust);
+                let peer = Peer::new(&discovered, this.name, this.trust);
                 Poll::Ready(Some(Ok(peer)))
             }
             Poll::Ready(Some(Err(e))) => Poll::Ready(Some(Err(e))),
@@ -47,10 +47,11 @@ pub struct SwarmEngine {
 
 impl SwarmEngine {
     /// Build an engine for a specific ALPN using the provided feed specs.
+    #[must_use] 
     pub fn new(local_id: EndpointId, alpn: &[u8], mut feeds: Vec<PeerFeedSpec>) -> Self {
         let mut inner = SelectAll::new();
         feeds.sort_by_key(|f| f.priority);
-        for spec in feeds.into_iter() {
+        for spec in feeds {
             if !scope_matches(&spec.scope, alpn) {
                 continue;
             }

--- a/src/swarm/engine.rs
+++ b/src/swarm/engine.rs
@@ -47,7 +47,7 @@ pub struct SwarmEngine {
 
 impl SwarmEngine {
     /// Build an engine for a specific ALPN using the provided feed specs.
-    #[must_use] 
+    #[must_use]
     pub fn new(local_id: EndpointId, alpn: &[u8], mut feeds: Vec<PeerFeedSpec>) -> Self {
         let mut inner = SelectAll::new();
         feeds.sort_by_key(|f| f.priority);

--- a/src/swarm/locator.rs
+++ b/src/swarm/locator.rs
@@ -50,14 +50,26 @@ pub struct Locator {
 
 impl Locator {
     /// Await the first successful channel and stop the background task.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no peer could be reached.
     pub async fn first(mut self) -> Result<Channel> {
-        match self.rx.recv().await {
-            Some(res) => {
-                self.task.abort();
-                res
+        let mut last_error = None;
+
+        while let Some(res) = self.rx.recv().await {
+            match res {
+                Ok(channel) => {
+                    self.task.abort();
+                    return Ok(channel);
+                }
+                Err(err) => {
+                    last_error = Some(err);
+                }
             }
-            None => Err(crate::Error::connection("no peers reachable")),
         }
+
+        Err(last_error.unwrap_or_else(|| crate::Error::connection("no peers reachable")))
     }
 
     /// Spawn a locator over a stream of peers.
@@ -161,7 +173,7 @@ where
                                     source = peer.source(),
                                     "locator: discovered peer, pushing connect attempt"
                                 );
-                                self.push_attempt(peer);
+                                self.push_attempt(&peer);
                             }
                             Some(Err(err)) => {
                                 debug!(?err, "locator: discovery stream error");
@@ -184,7 +196,7 @@ where
         }
     }
 
-    fn push_attempt(&mut self, peer: Peer) {
+    fn push_attempt(&mut self, peer: &Peer) {
         let ep = self.endpoint.clone();
         let timeout = self.opts.timeout_each;
         let node_id = peer.id();
@@ -194,5 +206,52 @@ where
             builder.await
         });
         self.inflight.push(fut);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use tokio::sync::mpsc;
+    use tonic::transport::Endpoint;
+
+    use super::Locator;
+
+    #[tokio::test]
+    async fn first_skips_errors_until_success() {
+        let (tx, rx) = mpsc::channel(4);
+        let task = tokio::spawn(async move {
+            tx.send(Err(crate::Error::connection("initial failure")))
+                .await
+                .expect("error send should succeed");
+            tx.send(Ok(Endpoint::from_static("http://[::]:50051").connect_lazy()))
+                .await
+                .expect("success send should succeed");
+        });
+
+        let locator = Locator { task, rx };
+        let result = locator.first().await;
+
+        assert!(result.is_ok(), "expected success after initial failure");
+    }
+
+    #[tokio::test]
+    async fn first_returns_last_error_if_no_success_arrives() {
+        let (tx, rx) = mpsc::channel(4);
+        let task = tokio::spawn(async move {
+            tx.send(Err(crate::Error::connection("first failure")))
+                .await
+                .expect("first error send should succeed");
+            tx.send(Err(crate::Error::connection("final failure")))
+                .await
+                .expect("second error send should succeed");
+        });
+
+        let locator = Locator { task, rx };
+        let result = locator.first().await;
+
+        match result {
+            Err(crate::Error::Connection(message)) => assert_eq!(message, "final failure"),
+            other => panic!("expected final connection error, got {other:?}"),
+        }
     }
 }

--- a/src/swarm/peers.rs
+++ b/src/swarm/peers.rs
@@ -43,7 +43,7 @@ pub struct PeerFeedSpec {
 pub type PeerFeed = Pin<Box<dyn Stream<Item = Result<DiscoveredPeer>> + Send>>;
 
 /// Build a finite feed from static peers.
-#[must_use] 
+#[must_use]
 pub fn static_feed(peers: Vec<EndpointId>, priority: u8, trust: u8, scope: Scope) -> PeerFeedSpec {
     let peer_trust = trust;
     let stream = futures_util::stream::iter(peers.into_iter().map(move |id| {
@@ -63,7 +63,7 @@ pub fn static_feed(peers: Vec<EndpointId>, priority: u8, trust: u8, scope: Scope
 }
 
 /// Build an mDNS feed scoped to a service ALPN.
-#[must_use] 
+#[must_use]
 pub fn mdns_feed(
     mdns: Arc<MdnsAddressLookup>,
     alpn: Vec<u8>,
@@ -104,7 +104,7 @@ pub fn mdns_feed(
 }
 
 /// Build a DHT feed (initial burst + periodic poll) for a service ALPN.
-#[must_use] 
+#[must_use]
 pub fn dht_feed(
     dht: Arc<Dht>,
     alpn: Vec<u8>,
@@ -200,7 +200,7 @@ pub fn dht_feed(
 }
 
 /// Build a peer-exchange feed backed by a broadcast channel.
-#[must_use] 
+#[must_use]
 pub fn peer_exchange_feed(
     rx: broadcast::Receiver<EndpointId>,
     priority: u8,
@@ -226,7 +226,7 @@ pub fn peer_exchange_feed(
 }
 
 /// Check if a scope applies to an ALPN.
-#[must_use] 
+#[must_use]
 pub fn scope_matches(scope: &Scope, alpn: &[u8]) -> bool {
     match scope {
         Scope::Any => true,

--- a/src/swarm/peers.rs
+++ b/src/swarm/peers.rs
@@ -2,7 +2,7 @@
 
 use std::{pin::Pin, sync::Arc, time::Duration};
 
-use futures_util::{Stream, StreamExt};
+use futures_util::{stream, Stream, StreamExt};
 use iroh::address_lookup::mdns::{DiscoveryEvent, MdnsAddressLookup};
 use iroh::EndpointId;
 use mainline::Dht;
@@ -10,10 +10,10 @@ use tokio::sync::broadcast;
 use tokio_stream::wrappers::{BroadcastStream, IntervalStream};
 use tracing::{debug, trace};
 
-use crate::user_data::user_data_has_alpn;
+use crate::user_data::{classify_user_data_alpn, UserDataAlpnMatch};
 use crate::Result;
 
-use super::dht::{resolver::DhtResolver, unix_minute};
+use super::dht::{resolver::DhtResolver, unix_minute, DHT_QUERY_CONCURRENCY, DHT_SHARD_COUNT};
 use super::discovery::DiscoveredPeer;
 
 /// Scope for feed applicability.
@@ -43,6 +43,7 @@ pub struct PeerFeedSpec {
 pub type PeerFeed = Pin<Box<dyn Stream<Item = Result<DiscoveredPeer>> + Send>>;
 
 /// Build a finite feed from static peers.
+#[must_use] 
 pub fn static_feed(peers: Vec<EndpointId>, priority: u8, trust: u8, scope: Scope) -> PeerFeedSpec {
     let peer_trust = trust;
     let stream = futures_util::stream::iter(peers.into_iter().map(move |id| {
@@ -62,6 +63,7 @@ pub fn static_feed(peers: Vec<EndpointId>, priority: u8, trust: u8, scope: Scope
 }
 
 /// Build an mDNS feed scoped to a service ALPN.
+#[must_use] 
 pub fn mdns_feed(
     mdns: Arc<MdnsAddressLookup>,
     alpn: Vec<u8>,
@@ -75,9 +77,14 @@ pub fn mdns_feed(
         while let Some(event) = sub.next().await {
             if let DiscoveryEvent::Discovered { endpoint_info, .. } = event {
                 let node_id = endpoint_info.endpoint_id;
-                if let Some(user_data) = endpoint_info.data.user_data() {
-                    if !user_data_has_alpn(user_data, &alpn) {
+                match classify_user_data_alpn(endpoint_info.data.user_data(), &alpn) {
+                    UserDataAlpnMatch::Match => {}
+                    UserDataAlpnMatch::Mismatch => {
                         trace!(alpn = %String::from_utf8_lossy(&alpn), "mdns: ALPN mismatch, skipping");
+                        continue;
+                    }
+                    UserDataAlpnMatch::Missing => {
+                        trace!(alpn = %String::from_utf8_lossy(&alpn), "mdns: missing service metadata, skipping");
                         continue;
                     }
                 }
@@ -97,6 +104,7 @@ pub fn mdns_feed(
 }
 
 /// Build a DHT feed (initial burst + periodic poll) for a service ALPN.
+#[must_use] 
 pub fn dht_feed(
     dht: Arc<Dht>,
     alpn: Vec<u8>,
@@ -114,14 +122,32 @@ pub fn dht_feed(
     let burst = async_stream::try_stream! {
         for offset in [0i64, -1] {
             let minute = unix_minute(offset);
-            if let Some(record) = burst_resolver.query_minute(&burst_alpn, minute).await {
-                if !required.is_empty() && !record.has_tags(&required) {
-                    trace!("Skipping DHT record (tags mismatch)");
-                    continue;
+            let queries = stream::iter(0..DHT_SHARD_COUNT)
+                .map({
+                    let resolver = burst_resolver.clone();
+                    let alpn = burst_alpn.clone();
+                    move |shard| {
+                        let resolver = resolver.clone();
+                        let alpn = alpn.clone();
+                        async move { resolver.query_shard(&alpn, minute, shard).await }
+                    }
+                })
+                .buffer_unordered(DHT_QUERY_CONCURRENCY);
+
+            futures_util::pin_mut!(queries);
+            while let Some(ads) = queries.next().await {
+                let ads = ads?;
+                for ad in ads {
+                    if !required.is_empty() && !ad.has_tags(&required) {
+                        trace!("Skipping DHT record (tags mismatch)");
+                        continue;
+                    }
+                    let Some(id) = ad.endpoint_id() else {
+                        continue;
+                    };
+                    debug!(%id, source = "dht", "discovered peer");
+                    yield DiscoveredPeer { id, trust: peer_trust };
                 }
-                let id = record.endpoint_id();
-                debug!(%id, source = "dht", "discovered peer");
-                yield DiscoveredPeer { id, trust: peer_trust };
             }
         }
     };
@@ -135,11 +161,29 @@ pub fn dht_feed(
         let _ = interval.next().await;
         while interval.next().await.is_some() {
             let minute = unix_minute(0);
-            if let Some(record) = poll_resolver.query_minute(&poll_alpn, minute).await {
-                if !required_poll.is_empty() && !record.has_tags(&required_poll) {
-                    continue;
+            let queries = stream::iter(0..DHT_SHARD_COUNT)
+                .map({
+                    let resolver = poll_resolver.clone();
+                    let alpn = poll_alpn.clone();
+                    move |shard| {
+                        let resolver = resolver.clone();
+                        let alpn = alpn.clone();
+                        async move { resolver.query_shard(&alpn, minute, shard).await }
+                    }
+                })
+                .buffer_unordered(DHT_QUERY_CONCURRENCY);
+
+            futures_util::pin_mut!(queries);
+            while let Some(ads) = queries.next().await {
+                let ads = ads?;
+                for ad in ads {
+                    if !required_poll.is_empty() && !ad.has_tags(&required_poll) {
+                        continue;
+                    }
+                    if let Some(id) = ad.endpoint_id() {
+                        yield DiscoveredPeer { id, trust: peer_trust };
+                    }
                 }
-                yield DiscoveredPeer { id: record.endpoint_id(), trust: peer_trust };
             }
         }
     };
@@ -156,6 +200,7 @@ pub fn dht_feed(
 }
 
 /// Build a peer-exchange feed backed by a broadcast channel.
+#[must_use] 
 pub fn peer_exchange_feed(
     rx: broadcast::Receiver<EndpointId>,
     priority: u8,
@@ -181,6 +226,7 @@ pub fn peer_exchange_feed(
 }
 
 /// Check if a scope applies to an ALPN.
+#[must_use] 
 pub fn scope_matches(scope: &Scope, alpn: &[u8]) -> bool {
     match scope {
         Scope::Any => true,

--- a/src/swarm/record.rs
+++ b/src/swarm/record.rs
@@ -1,27 +1,370 @@
-//! Service record stored in DHT.
+//! DHT record types for signed service advertisements.
 
-use iroh::EndpointId;
+use std::cmp::Reverse;
+use std::collections::{btree_map::Entry, BTreeMap};
+
+use iroh::{EndpointId, SecretKey, Signature};
 use serde::{Deserialize, Serialize};
 
-/// Content stored in DHT records for service discovery.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ServiceRecord {
-    /// The iroh node ID bytes (32 bytes).
+pub(crate) const DHT_BUCKET_VERSION: u8 = 2;
+pub(crate) const DHT_MAX_BUCKET_BYTES: usize = 1000;
+const MAX_FUTURE_SKEW_SECS: u64 = 300;
+
+/// A single signed service advertisement stored inside a DHT shard bucket.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct SignedServiceAd {
+    ad: ServiceAd,
+    signature: Signature,
+}
+
+/// The unsigned service advertisement payload.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceAd {
+    /// The advertising iroh node ID bytes.
     pub node_id: [u8; 32],
     /// Optional coarse tags for filtering.
     pub tags: Vec<String>,
     /// Unix timestamp when published.
     pub published_at: u64,
+    /// Unix timestamp after which the ad should be discarded.
+    pub expires_at: u64,
 }
 
-impl ServiceRecord {
-    /// Return the `EndpointId` contained in this record.
-    pub fn endpoint_id(&self) -> EndpointId {
-        EndpointId::from_bytes(&self.node_id).expect("invalid node_id in record")
+/// A bounded, shared mutable bucket of signed service advertisements.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ServiceBucket {
+    /// Bucket format version for clean cutovers.
+    pub version: u8,
+    /// Signed ads currently held in this shard.
+    pub ads: Vec<SignedServiceAd>,
+}
+
+#[derive(Debug, Serialize)]
+struct ServiceAdEnvelope<'a> {
+    version: u8,
+    alpn: &'a [u8],
+    minute: u64,
+    shard: u8,
+    node_id: [u8; 32],
+    tags: &'a [String],
+    published_at: u64,
+    expires_at: u64,
+}
+
+impl SignedServiceAd {
+    /// Create and sign a service advertisement for a specific shard bucket.
+    pub(crate) fn sign(
+        secret_key: &SecretKey,
+        alpn: &[u8],
+        minute: u64,
+        shard: u8,
+        tags: &[String],
+        published_at: u64,
+        expires_at: u64,
+    ) -> postcard::Result<Self> {
+        let ad = ServiceAd {
+            node_id: *secret_key.public().as_bytes(),
+            tags: tags.to_vec(),
+            published_at,
+            expires_at,
+        };
+        let message = signing_message(alpn, minute, shard, &ad)?;
+        Ok(Self {
+            signature: secret_key.sign(&message),
+            ad,
+        })
     }
 
-    /// Check that all required tags are present.
-    pub fn has_tags(&self, required_tags: &[String]) -> bool {
-        required_tags.iter().all(|t| self.tags.contains(t))
+    /// Return the advertised endpoint id if the bytes decode to a valid iroh id.
+    pub(crate) fn endpoint_id(&self) -> Option<EndpointId> {
+        EndpointId::from_bytes(&self.ad.node_id).ok()
+    }
+
+    /// Return the advertised node id bytes.
+    pub(crate) fn node_id(&self) -> [u8; 32] {
+        self.ad.node_id
+    }
+
+    /// Check whether the ad contains all required tags.
+    pub(crate) fn has_tags(&self, required_tags: &[String]) -> bool {
+        required_tags.iter().all(|tag| self.ad.tags.contains(tag))
+    }
+
+    pub(crate) fn published_at(&self) -> u64 {
+        self.ad.published_at
+    }
+
+    pub(crate) fn expires_at(&self) -> u64 {
+        self.ad.expires_at
+    }
+
+    /// Validate the ad against the bucket namespace and current time.
+    pub(crate) fn verify(&self, alpn: &[u8], minute: u64, shard: u8, now: u64) -> bool {
+        if self.ad.expires_at <= now
+            || self.ad.published_at > self.ad.expires_at
+            || self.ad.published_at > now.saturating_add(MAX_FUTURE_SKEW_SECS)
+        {
+            return false;
+        }
+
+        let Some(endpoint_id) = self.endpoint_id() else {
+            return false;
+        };
+
+        match signing_message(alpn, minute, shard, &self.ad) {
+            Ok(message) => endpoint_id.verify(&message, &self.signature).is_ok(),
+            Err(_) => false,
+        }
+    }
+}
+
+impl ServiceBucket {
+    /// Build a new bucket with the current format version.
+    pub(crate) fn new(ads: Vec<SignedServiceAd>) -> Self {
+        Self {
+            version: DHT_BUCKET_VERSION,
+            ads,
+        }
+    }
+
+    /// Merge and deduplicate valid ads from multiple bucket replicas.
+    pub(crate) fn merge_valid(
+        buckets: impl IntoIterator<Item = ServiceBucket>,
+        alpn: &[u8],
+        minute: u64,
+        shard: u8,
+        now: u64,
+    ) -> Vec<SignedServiceAd> {
+        let mut merged = BTreeMap::<[u8; 32], SignedServiceAd>::new();
+
+        for bucket in buckets {
+            if bucket.version != DHT_BUCKET_VERSION {
+                continue;
+            }
+
+            for ad in bucket.ads {
+                if !ad.verify(alpn, minute, shard, now) {
+                    continue;
+                }
+
+                match merged.entry(ad.node_id()) {
+                    Entry::Vacant(entry) => {
+                        entry.insert(ad);
+                    }
+                    Entry::Occupied(mut entry) if ad_precedes(&ad, entry.get()) => {
+                        entry.insert(ad);
+                    }
+                    Entry::Occupied(_) => {}
+                }
+            }
+        }
+
+        let mut ads: Vec<_> = merged.into_values().collect();
+        ads.sort_by_key(ad_sort_key);
+        ads
+    }
+
+    /// Insert or replace a signed advertisement by node id.
+    pub(crate) fn upsert(&mut self, ad: SignedServiceAd) {
+        if let Some(existing) = self
+            .ads
+            .iter_mut()
+            .find(|existing| existing.node_id() == ad.node_id())
+        {
+            if ad_precedes(&ad, existing) {
+                *existing = ad;
+            }
+            return;
+        }
+        self.ads.push(ad);
+    }
+
+    /// Trim the bucket until it fits the BEP44 value size limit.
+    ///
+    /// Returns `false` if the preferred ad alone does not fit.
+    pub(crate) fn trim_to_size(
+        &mut self,
+        preferred_node: Option<[u8; 32]>,
+    ) -> postcard::Result<bool> {
+        self.ads
+            .sort_by_key(|ad| preferred_ad_sort_key(ad, preferred_node));
+
+        loop {
+            if self.encoded_len()? <= DHT_MAX_BUCKET_BYTES {
+                return Ok(true);
+            }
+
+            let removal_idx = self
+                .ads
+                .iter()
+                .rposition(|ad| Some(ad.node_id()) != preferred_node);
+
+            match removal_idx {
+                Some(idx) => {
+                    self.ads.remove(idx);
+                }
+                None => break,
+            }
+        }
+
+        Ok(self.encoded_len()? <= DHT_MAX_BUCKET_BYTES)
+    }
+
+    fn encoded_len(&self) -> postcard::Result<usize> {
+        postcard::to_allocvec(self).map(|bytes| bytes.len())
+    }
+}
+
+fn signing_message(
+    alpn: &[u8],
+    minute: u64,
+    shard: u8,
+    ad: &ServiceAd,
+) -> postcard::Result<Vec<u8>> {
+    postcard::to_allocvec(&ServiceAdEnvelope {
+        version: DHT_BUCKET_VERSION,
+        alpn,
+        minute,
+        shard,
+        node_id: ad.node_id,
+        tags: &ad.tags,
+        published_at: ad.published_at,
+        expires_at: ad.expires_at,
+    })
+}
+
+fn ad_precedes(candidate: &SignedServiceAd, existing: &SignedServiceAd) -> bool {
+    ad_sort_key(candidate) < ad_sort_key(existing)
+}
+
+fn ad_sort_key(ad: &SignedServiceAd) -> (Reverse<u64>, Reverse<u64>, [u8; 32]) {
+    (
+        Reverse(ad.published_at()),
+        Reverse(ad.expires_at()),
+        ad.node_id(),
+    )
+}
+
+fn preferred_ad_sort_key(
+    ad: &SignedServiceAd,
+    preferred_node: Option<[u8; 32]>,
+) -> (bool, Reverse<u64>, Reverse<u64>, [u8; 32]) {
+    let deprioritized = matches!(preferred_node, Some(node_id) if ad.node_id() != node_id);
+    (
+        deprioritized,
+        Reverse(ad.published_at()),
+        Reverse(ad.expires_at()),
+        ad.node_id(),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use iroh::SecretKey;
+
+    use super::*;
+
+    #[test]
+    fn signed_ad_round_trips() {
+        let key = SecretKey::from([7u8; 32]);
+        let ad = SignedServiceAd::sign(
+            &key,
+            b"/svc.Test/1.0",
+            123,
+            4,
+            &["prod".to_string()],
+            1_000,
+            1_120,
+        )
+        .expect("ad should serialize");
+
+        assert!(ad.verify(b"/svc.Test/1.0", 123, 4, 1_060));
+        assert!(!ad.verify(b"/svc.Test/1.0", 123, 5, 1_060));
+        assert!(!ad.verify(b"/svc.Other/1.0", 123, 4, 1_060));
+    }
+
+    #[test]
+    fn merge_valid_dedupes_and_prefers_newer_ads() {
+        let key = SecretKey::from([9u8; 32]);
+        let newer = SignedServiceAd::sign(&key, b"/svc.Test/1.0", 55, 2, &[], 200, 320)
+            .expect("newer ad should serialize");
+        let older = SignedServiceAd::sign(
+            &key,
+            b"/svc.Test/1.0",
+            55,
+            2,
+            &["old".to_string()],
+            100,
+            220,
+        )
+        .expect("older ad should serialize");
+        let invalid = SignedServiceAd::sign(
+            &SecretKey::from([3u8; 32]),
+            b"/svc.Test/1.0",
+            55,
+            3,
+            &[],
+            100,
+            220,
+        )
+        .expect("invalid ad should serialize");
+
+        let merged = ServiceBucket::merge_valid(
+            [
+                ServiceBucket::new(vec![older]),
+                ServiceBucket::new(vec![newer.clone(), invalid]),
+            ],
+            b"/svc.Test/1.0",
+            55,
+            2,
+            210,
+        );
+
+        assert_eq!(merged, vec![newer]);
+    }
+
+    #[test]
+    fn trim_to_size_preserves_preferred_ad() {
+        let preferred = SecretKey::from([1u8; 32]);
+        let other = SecretKey::from([2u8; 32]);
+        let mut bucket = ServiceBucket::new(
+            (0..24)
+                .map(|idx| {
+                    let key = if idx == 0 {
+                        preferred.clone()
+                    } else {
+                        SecretKey::from([idx as u8; 32])
+                    };
+                    SignedServiceAd::sign(
+                        &key,
+                        b"/svc.Test/1.0",
+                        77,
+                        3,
+                        &[],
+                        1_000 + idx,
+                        1_120 + idx,
+                    )
+                    .expect("ad should serialize")
+                })
+                .chain(std::iter::once(
+                    SignedServiceAd::sign(&other, b"/svc.Test/1.0", 77, 3, &[], 900, 1_020)
+                        .expect("ad should serialize"),
+                ))
+                .collect(),
+        );
+
+        let preferred_id = *preferred.public().as_bytes();
+        let kept = bucket
+            .trim_to_size(Some(preferred_id))
+            .expect("bucket trim should serialize");
+
+        assert!(kept);
+        assert!(bucket.ads.iter().any(|ad| ad.node_id() == preferred_id));
+        assert!(
+            postcard::to_allocvec(&bucket)
+                .expect("bucket should serialize")
+                .len()
+                <= DHT_MAX_BUCKET_BYTES
+        );
     }
 }

--- a/src/swarm/registry.rs
+++ b/src/swarm/registry.rs
@@ -23,7 +23,7 @@ pub struct ServiceRegistry {
 
 impl ServiceRegistry {
     /// Create an empty registry with no backends.
-    #[must_use] 
+    #[must_use]
     pub fn new(endpoint: &Endpoint) -> Self {
         Self {
             endpoint: endpoint.clone(),
@@ -44,7 +44,7 @@ impl ServiceRegistry {
     }
 
     /// Access the endpoint.
-    #[must_use] 
+    #[must_use]
     pub fn endpoint(&self) -> &Endpoint {
         &self.endpoint
     }
@@ -57,7 +57,7 @@ impl ServiceRegistry {
     }
 
     /// Build a locator builder for racing connections.
-    #[must_use] 
+    #[must_use]
     pub fn find<S: NamedService + Send + 'static>(&self) -> LocatorBuilder<'_, S> {
         LocatorBuilder::new(self)
     }
@@ -90,35 +90,35 @@ where
     }
 
     /// Maximum simultaneous connection attempts.
-    #[must_use] 
+    #[must_use]
     pub fn max_inflight(mut self, n: usize) -> Self {
         self.locator_cfg.max_inflight = n;
         self
     }
 
     /// Timeout for each individual attempt.
-    #[must_use] 
+    #[must_use]
     pub fn timeout_each(mut self, d: Duration) -> Self {
         self.locator_cfg.timeout_each = d;
         self
     }
 
     /// Overall timeout for the locator.
-    #[must_use] 
+    #[must_use]
     pub fn timeout(mut self, d: Duration) -> Self {
         self.locator_cfg.timeout = Some(d);
         self
     }
 
     /// Buffer size for successful connections.
-    #[must_use] 
+    #[must_use]
     pub fn limit(mut self, n: usize) -> Self {
         self.locator_cfg.limit = n;
         self
     }
 
     /// Start the locator and return its handle.
-    #[must_use] 
+    #[must_use]
     pub fn start(self) -> Locator {
         let alpn = service_to_alpn::<S>();
         let feeds = self.registry.build_feeds(&alpn);

--- a/src/swarm/registry.rs
+++ b/src/swarm/registry.rs
@@ -1,4 +1,4 @@
-//! ServiceRegistry: owns pluggable discovery backends and builds locators.
+//! `ServiceRegistry`: owns pluggable discovery backends and builds locators.
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -23,6 +23,7 @@ pub struct ServiceRegistry {
 
 impl ServiceRegistry {
     /// Create an empty registry with no backends.
+    #[must_use] 
     pub fn new(endpoint: &Endpoint) -> Self {
         Self {
             endpoint: endpoint.clone(),
@@ -43,6 +44,7 @@ impl ServiceRegistry {
     }
 
     /// Access the endpoint.
+    #[must_use] 
     pub fn endpoint(&self) -> &Endpoint {
         &self.endpoint
     }
@@ -55,6 +57,7 @@ impl ServiceRegistry {
     }
 
     /// Build a locator builder for racing connections.
+    #[must_use] 
     pub fn find<S: NamedService + Send + 'static>(&self) -> LocatorBuilder<'_, S> {
         LocatorBuilder::new(self)
     }
@@ -87,30 +90,35 @@ where
     }
 
     /// Maximum simultaneous connection attempts.
+    #[must_use] 
     pub fn max_inflight(mut self, n: usize) -> Self {
         self.locator_cfg.max_inflight = n;
         self
     }
 
     /// Timeout for each individual attempt.
+    #[must_use] 
     pub fn timeout_each(mut self, d: Duration) -> Self {
         self.locator_cfg.timeout_each = d;
         self
     }
 
     /// Overall timeout for the locator.
+    #[must_use] 
     pub fn timeout(mut self, d: Duration) -> Self {
         self.locator_cfg.timeout = Some(d);
         self
     }
 
     /// Buffer size for successful connections.
+    #[must_use] 
     pub fn limit(mut self, n: usize) -> Self {
         self.locator_cfg.limit = n;
         self
     }
 
     /// Start the locator and return its handle.
+    #[must_use] 
     pub fn start(self) -> Locator {
         let alpn = service_to_alpn::<S>();
         let feeds = self.registry.build_feeds(&alpn);
@@ -119,6 +127,10 @@ where
     }
 
     /// Convenience: return the first successful channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if no peer could be reached.
     pub async fn first(self) -> crate::Result<Channel> {
         self.start().first().await
     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -75,7 +75,7 @@ pub struct TransportBuilder {
 
 impl TransportBuilder {
     /// Create a new builder for an endpoint.
-    #[must_use] 
+    #[must_use]
     pub fn new(endpoint: Endpoint) -> Self {
         Self {
             endpoint,
@@ -89,7 +89,7 @@ impl TransportBuilder {
 
     /// Enable DHT publishing with a pre-configured publisher.
     #[cfg(feature = "discovery")]
-    #[must_use] 
+    #[must_use]
     pub fn with_publisher(mut self, publisher: DhtPublisher) -> Self {
         self.publisher = Some(publisher);
         self
@@ -118,7 +118,7 @@ impl TransportBuilder {
     ///
     /// When the queue is full, newly accepted streams are rejected immediately
     /// instead of being buffered unboundedly in memory.
-    #[must_use] 
+    #[must_use]
     pub fn incoming_buffer_capacity(mut self, capacity: usize) -> Self {
         self.incoming_buffer_capacity = capacity.max(1);
         self
@@ -207,13 +207,13 @@ pub struct TransportGuard {
 
 impl TransportGuard {
     /// Access the endpoint.
-    #[must_use] 
+    #[must_use]
     pub fn endpoint(&self) -> &Endpoint {
         &self.endpoint
     }
 
     /// Access the router handle.
-    #[must_use] 
+    #[must_use]
     pub fn router(&self) -> &Router {
         &self.router
     }

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -12,7 +12,7 @@ use tonic::transport::Server;
 
 use crate::alpn::service_to_alpn;
 use crate::error::Result;
-use crate::server::{GrpcProtocolHandler, IrohIncoming};
+use crate::server::{GrpcProtocolHandler, IrohIncoming, DEFAULT_INCOMING_BUFFER_CAPACITY};
 use crate::user_data::encode_alpns;
 
 #[cfg(feature = "discovery")]
@@ -23,7 +23,7 @@ trait AddService: Send {
     fn register(
         self: Box<Self>,
         router: RouterBuilder,
-        sender: tokio::sync::mpsc::UnboundedSender<
+        sender: tokio::sync::mpsc::Sender<
             std::result::Result<crate::stream::IrohStream, std::io::Error>,
         >,
         tonic_router: Option<TonicRouter>,
@@ -44,7 +44,7 @@ where
     fn register(
         self: Box<Self>,
         router: RouterBuilder,
-        sender: tokio::sync::mpsc::UnboundedSender<
+        sender: tokio::sync::mpsc::Sender<
             std::result::Result<crate::stream::IrohStream, std::io::Error>,
         >,
         tonic_router: Option<TonicRouter>,
@@ -68,17 +68,20 @@ pub struct TransportBuilder {
     endpoint: Endpoint,
     services: Vec<Box<dyn AddService>>,
     alpns: Vec<Vec<u8>>,
+    incoming_buffer_capacity: usize,
     #[cfg(feature = "discovery")]
     publisher: Option<DhtPublisher>,
 }
 
 impl TransportBuilder {
     /// Create a new builder for an endpoint.
+    #[must_use] 
     pub fn new(endpoint: Endpoint) -> Self {
         Self {
             endpoint,
             services: Vec::new(),
             alpns: Vec::new(),
+            incoming_buffer_capacity: DEFAULT_INCOMING_BUFFER_CAPACITY,
             #[cfg(feature = "discovery")]
             publisher: None,
         }
@@ -86,12 +89,14 @@ impl TransportBuilder {
 
     /// Enable DHT publishing with a pre-configured publisher.
     #[cfg(feature = "discovery")]
+    #[must_use] 
     pub fn with_publisher(mut self, publisher: DhtPublisher) -> Self {
         self.publisher = Some(publisher);
         self
     }
 
     /// Add a tonic RPC service.
+    #[must_use]
     pub fn add_rpc<S>(mut self, service: S) -> Self
     where
         S: NamedService
@@ -109,44 +114,59 @@ impl TransportBuilder {
         self
     }
 
+    /// Set the maximum number of accepted RPC streams buffered for tonic.
+    ///
+    /// When the queue is full, newly accepted streams are rejected immediately
+    /// instead of being buffered unboundedly in memory.
+    #[must_use] 
+    pub fn incoming_buffer_capacity(mut self, capacity: usize) -> Self {
+        self.incoming_buffer_capacity = capacity.max(1);
+        self
+    }
+
     /// Spawn the transport (router, tonic server).
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if ALPN metadata encoding fails or the router cannot be built.
+    #[allow(clippy::unused_async)]
     pub async fn spawn(self) -> Result<TransportGuard> {
         let (shutdown_tx, _) = broadcast::channel(1);
-        let (incoming, sender) = IrohIncoming::new();
+        let (incoming, sender) = IrohIncoming::new(self.incoming_buffer_capacity);
         let mut builder = Router::builder(self.endpoint.clone());
         let mut tonic_router: Option<TonicRouter> = None;
 
-        for svc in self.services.into_iter() {
+        for svc in self.services {
             let (b, tr) = svc.register(builder, sender.clone(), tonic_router);
             builder = b;
             tonic_router = Some(tr);
         }
 
         if !self.alpns.is_empty() {
-            let user_data = encode_alpns(&self.alpns);
+            let user_data = encode_alpns(&self.alpns)?;
             self.endpoint
                 .set_user_data_for_address_lookup(Some(user_data));
         }
 
         // Start DHT publisher if one was provided
-        #[cfg(feature = "discovery")]
-        let dht_publisher = if let Some(mut publisher) = self.publisher {
-            for alpn in &self.alpns {
-                publisher.add_service(alpn.clone());
-            }
-            publisher.start(shutdown_tx.subscribe());
-            Some(publisher)
-        } else {
-            None
-        };
-
         let router = builder.spawn();
 
         let mut driver = JoinSet::new();
 
+        #[cfg(feature = "discovery")]
+        if let Some(mut publisher) = self.publisher {
+            for alpn in &self.alpns {
+                publisher.add_service(alpn.clone());
+            }
+
+            let shutdown_rx = shutdown_tx.subscribe();
+            driver.spawn(async move {
+                publisher.run(shutdown_rx).await;
+            });
+        }
+
         if let Some(tr) = tonic_router {
             let mut shutdown_rx = shutdown_tx.subscribe();
-            let incoming = incoming;
             driver.spawn(async move {
                 let shutdown_fut = async move {
                     let _ = shutdown_rx.recv().await;
@@ -173,8 +193,6 @@ impl TransportBuilder {
             shutdown_tx,
             driver: driver_handle,
             router,
-            #[cfg(feature = "discovery")]
-            dht_publisher,
         })
     }
 }
@@ -185,34 +203,38 @@ pub struct TransportGuard {
     shutdown_tx: broadcast::Sender<()>,
     driver: tokio::task::JoinHandle<()>,
     router: Router,
-    #[cfg(feature = "discovery")]
-    dht_publisher: Option<DhtPublisher>,
 }
 
 impl TransportGuard {
     /// Access the endpoint.
+    #[must_use] 
     pub fn endpoint(&self) -> &Endpoint {
         &self.endpoint
     }
 
     /// Access the router handle.
-    pub fn router(&self) -> Option<&Router> {
-        Some(&self.router)
+    #[must_use] 
+    pub fn router(&self) -> &Router {
+        &self.router
     }
 
     /// Graceful shutdown of tonic and router.
-    #[allow(unused_mut)]
-    pub async fn shutdown(mut self) -> Result<()> {
-        let _ = self.shutdown_tx.send(());
-        let _ = self.driver.await;
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the router shutdown fails.
+    pub async fn shutdown(self) -> Result<()> {
+        let TransportGuard {
+            shutdown_tx,
+            driver,
+            router,
+            ..
+        } = self;
 
-        // Stop DHT publisher if running
-        #[cfg(feature = "discovery")]
-        if let Some(ref mut publisher) = self.dht_publisher {
-            publisher.stop().await;
-        }
+        let _ = shutdown_tx.send(());
+        let _ = driver.await;
 
-        if let Err(e) = self.router.shutdown().await {
+        if let Err(e) = router.shutdown().await {
             tracing::warn!("router shutdown error: {e}");
         }
 

--- a/src/user_data.rs
+++ b/src/user_data.rs
@@ -1,42 +1,123 @@
 //! Helpers for encoding and matching service ALPN data in iroh user-data records.
 
+use data_encoding::BASE64URL_NOPAD;
 use iroh::address_lookup::UserData;
 
 #[cfg(feature = "server")]
 use crate::alpn::service_to_alpn;
+#[cfg(feature = "server")]
+use crate::{Error, Result};
 
-const ALPN_SEPARATOR: char = ',';
+/// Classification for service-scoped discovery against published user-data.
+#[cfg(feature = "discovery")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum UserDataAlpnMatch {
+    /// The published metadata contains the required ALPN.
+    Match,
+    /// The published metadata is present but does not contain the ALPN.
+    Mismatch,
+    /// No service metadata was published.
+    Missing,
+}
 
 #[cfg(feature = "server")]
-pub(crate) fn encode_alpns(alpns: &[Vec<u8>]) -> UserData {
-    let strings: Vec<String> = alpns
-        .iter()
-        .filter_map(|a| String::from_utf8(a.clone()).ok())
-        .collect();
-    strings.join(&ALPN_SEPARATOR.to_string()).parse().unwrap()
+pub(crate) fn encode_alpns(alpns: &[Vec<u8>]) -> Result<UserData> {
+    let encoded = BASE64URL_NOPAD.encode(&postcard::to_allocvec(alpns).map_err(|e| {
+        Error::address_lookup_metadata(format!("failed to serialize ALPN metadata: {e}"))
+    })?);
+
+    encoded.parse().map_err(|_| {
+        Error::address_lookup_metadata(format!(
+            "encoded ALPN metadata exceeds {} bytes",
+            UserData::MAX_LENGTH
+        ))
+    })
 }
 
 fn decode_alpns(user_data: &UserData) -> Vec<Vec<u8>> {
-    let s: &str = user_data.as_ref();
-    s.split(ALPN_SEPARATOR)
-        .map(|part| part.as_bytes().to_vec())
-        .collect()
+    let encoded: &str = user_data.as_ref();
+    BASE64URL_NOPAD
+        .decode(encoded.as_bytes())
+        .ok()
+        .and_then(|bytes| postcard::from_bytes::<Vec<Vec<u8>>>(&bytes).ok())
+        .unwrap_or_default()
 }
 
-/// Check if user_data contains the ALPN for a specific tonic service.
+#[cfg(feature = "discovery")]
+pub(crate) fn classify_user_data_alpn(
+    user_data: Option<&UserData>,
+    alpn: &[u8],
+) -> UserDataAlpnMatch {
+    match user_data {
+        Some(user_data) if user_data_has_alpn(user_data, alpn) => UserDataAlpnMatch::Match,
+        Some(_) => UserDataAlpnMatch::Mismatch,
+        None => UserDataAlpnMatch::Missing,
+    }
+}
+
+/// Check if `user_data` contains the ALPN for a specific tonic service.
 #[cfg(feature = "server")]
+#[must_use] 
 pub fn user_data_has_service<S: tonic::server::NamedService>(user_data: &UserData) -> bool {
     let target = service_to_alpn::<S>();
     decode_alpns(user_data).iter().any(|alpn| alpn == &target)
 }
 
-/// Check if user_data contains a specific ALPN.
+/// Check if `user_data` contains a specific ALPN.
+#[must_use] 
 pub fn user_data_has_alpn(user_data: &UserData, alpn: &[u8]) -> bool {
     decode_alpns(user_data).iter().any(|a| a == alpn)
 }
 
-/// Get all ALPNs from user_data.
+/// Get all ALPNs from `user_data`.
 #[cfg(feature = "server")]
+#[must_use] 
 pub fn user_data_alpns(user_data: &UserData) -> Vec<Vec<u8>> {
     decode_alpns(user_data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{encode_alpns, user_data_alpns};
+    use iroh::address_lookup::UserData;
+
+    #[cfg(feature = "discovery")]
+    use super::{classify_user_data_alpn, UserDataAlpnMatch};
+
+    #[cfg(feature = "discovery")]
+    #[test]
+    fn classify_user_data_alpn_distinguishes_missing_match_and_mismatch() {
+        let user_data = encode_alpns(&[b"/svc.A/1.0".to_vec(), b"/svc.B/1.0".to_vec()])
+            .expect("valid user-data");
+
+        assert_eq!(
+            classify_user_data_alpn(Some(&user_data), b"/svc.A/1.0"),
+            UserDataAlpnMatch::Match
+        );
+        assert_eq!(
+            classify_user_data_alpn(Some(&user_data), b"/svc.C/1.0"),
+            UserDataAlpnMatch::Mismatch
+        );
+        assert_eq!(
+            classify_user_data_alpn(None, b"/svc.A/1.0"),
+            UserDataAlpnMatch::Missing
+        );
+    }
+
+    #[test]
+    fn encode_decode_round_trips_alpns_without_separator_collisions() {
+        let user_data = encode_alpns(&[b"/svc,comma/1.0".to_vec(), b"/svc.dot/1.0".to_vec()])
+            .expect("encoding should succeed");
+
+        assert_eq!(
+            user_data_alpns(&user_data),
+            vec![b"/svc,comma/1.0".to_vec(), b"/svc.dot/1.0".to_vec()]
+        );
+    }
+
+    #[test]
+    fn malformed_user_data_decodes_to_empty_set() {
+        let user_data: UserData = "%%%not-base64%%%".parse().expect("under max length");
+        assert!(user_data_alpns(&user_data).is_empty());
+    }
 }

--- a/src/user_data.rs
+++ b/src/user_data.rs
@@ -57,21 +57,21 @@ pub(crate) fn classify_user_data_alpn(
 
 /// Check if `user_data` contains the ALPN for a specific tonic service.
 #[cfg(feature = "server")]
-#[must_use] 
+#[must_use]
 pub fn user_data_has_service<S: tonic::server::NamedService>(user_data: &UserData) -> bool {
     let target = service_to_alpn::<S>();
     decode_alpns(user_data).iter().any(|alpn| alpn == &target)
 }
 
 /// Check if `user_data` contains a specific ALPN.
-#[must_use] 
+#[must_use]
 pub fn user_data_has_alpn(user_data: &UserData, alpn: &[u8]) -> bool {
     decode_alpns(user_data).iter().any(|a| a == alpn)
 }
 
 /// Get all ALPNs from `user_data`.
 #[cfg(feature = "server")]
-#[must_use] 
+#[must_use]
 pub fn user_data_alpns(user_data: &UserData) -> Vec<Vec<u8>> {
     decode_alpns(user_data)
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -142,6 +142,66 @@ async fn test_rpc_server_lifecycle() {
     guard.shutdown().await.unwrap();
 }
 
+#[tokio::test]
+async fn test_rpc_shutdown_closes_live_service_connection() {
+    use axum::body::Body as AxumBody;
+    use axum::response::Response;
+    use std::convert::Infallible;
+    use std::{future::Ready, task::Poll};
+    use tonic::body::Body;
+
+    #[derive(Clone)]
+    struct DummyRpc;
+    impl tonic::server::NamedService for DummyRpc {
+        const NAME: &'static str = "test.Service";
+    }
+    impl tower::Service<http::Request<Body>> for DummyRpc {
+        type Response = Response<AxumBody>;
+        type Error = Infallible;
+        type Future = Ready<Result<Self::Response, Self::Error>>;
+
+        fn poll_ready(
+            &mut self,
+            _cx: &mut std::task::Context<'_>,
+        ) -> Poll<Result<(), Self::Error>> {
+            Poll::Ready(Ok(()))
+        }
+
+        fn call(&mut self, _req: http::Request<Body>) -> Self::Future {
+            std::future::ready(Ok(Response::new(AxumBody::empty())))
+        }
+    }
+
+    let server_endpoint = local_endpoint().await;
+    let guard = TransportBuilder::new(server_endpoint.clone())
+        .add_rpc(DummyRpc)
+        .spawn()
+        .await
+        .unwrap();
+
+    let client_endpoint = local_endpoint().await;
+    let server_addr = EndpointAddr::new(server_endpoint.id())
+        .with_addrs(to_localhost_addrs(server_endpoint.bound_sockets()));
+    let conn = timeout(
+        Duration::from_secs(5),
+        client_endpoint.connect(server_addr, b"/test.Service/1.0"),
+    )
+    .await
+    .expect("connection timed out")
+    .expect("connection failed");
+
+    timeout(Duration::from_secs(5), guard.shutdown())
+        .await
+        .expect("shutdown timed out")
+        .expect("shutdown failed");
+
+    let open_result = timeout(Duration::from_secs(1), conn.open_bi()).await;
+    assert!(
+        matches!(open_result, Ok(Err(_)) | Err(_)),
+        "connection remained usable after server shutdown"
+    );
+}
+
 #[test_log::test(tokio::test)]
 async fn test_connect_timeout_builtin() {
     // Test using the built-in connect_timeout on ConnectBuilder


### PR DESCRIPTION
## Summary
- Replace direct-connect in echo example with mainline DHT discovery
- Server publishes to DHT via `TransportBuilder::with_publisher()`
- Client discovers via `ServiceRegistry` + `DhtBackend`
- Add CI step to run the example as an e2e integration test (3min timeout)

## Test plan
- [ ] CI passes: echo example runs end-to-end with DHT discovery