### PR TITLE
feat: add OpenTelemetry tracing instrumentation and trace context propagation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,7 +61,7 @@ hyper-util = { version = "0.1", default-features = false, optional = true }
 tower = { version = "0.4", features = ["util"], default-features = false, optional = true }
 futures-util = { version = "0.3", default-features = false }
 thiserror = { version = "2.0", default-features = false }
-tracing = { version = "0.1", default-features = false }
+tracing = { version = "0.1", default-features = false, features = ["attributes"] }
 bytes = { version = "1.8", default-features = false }
 axum = { version = "0.8", default-features = false, optional = true }
 data-encoding = { version = "2.9", default-features = false, optional = true }
@@ -80,6 +80,7 @@ tracing-subscriber = "0.3"
 anyhow = "1.0"
 async-trait = "0.1"
 test-log = "0.2"
+opentelemetry_sdk = { version = "0.31", features = ["trace"] }
 
 # Example dependencies
 clap = { version = "4.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tonic-iroh-transport"
 authors = ["George Whewell <george@hellas.ai>"]
-version = "0.6.1"
+version = "0.7.0"
 edition = "2021"
 description = "Transport layer for using tonic gRPC over iroh p2p connections"
 license = "MIT OR Apache-2.0"
@@ -49,6 +49,7 @@ discovery = [
     "dep:serde",
     "dep:postcard",
 ]
+otel = ["dep:opentelemetry"]
 
 [dependencies]
 iroh = { version = "0.97" }
@@ -71,6 +72,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 async-stream = { version = "0.3", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 postcard = { version = "1", optional = true, features = ["alloc"] }
+opentelemetry = { version = "0.31", optional = true, default-features = false, features = ["trace"] }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,7 @@ discovery = [
     "dep:serde",
     "dep:postcard",
 ]
-otel = ["dep:opentelemetry"]
+otel = ["dep:opentelemetry", "dep:tracing-opentelemetry"]
 
 [dependencies]
 iroh = { version = "0.97" }
@@ -73,6 +73,7 @@ async-stream = { version = "0.3", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 postcard = { version = "1", optional = true, features = ["alloc"] }
 opentelemetry = { version = "0.31", optional = true, default-features = false, features = ["trace"] }
+tracing-opentelemetry = { version = "0.32", optional = true, default-features = false }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/client.rs
+++ b/src/client.rs
@@ -36,7 +36,7 @@ use iroh::endpoint::{ConnectingError, ConnectionError, QuicTransportConfig};
 use iroh::EndpointAddr;
 use tonic::transport::{Channel, Endpoint};
 use tower::service_fn;
-use tracing::{debug, info};
+use tracing::{debug, info, Instrument};
 
 /// Map a `ConnectionError` to an appropriate `io::ErrorKind`.
 fn connection_error_to_io(e: ConnectionError) -> std::io::Error {
@@ -224,25 +224,28 @@ async fn connect_impl(
     connect_timeout: Option<Duration>,
     transport_config: Option<QuicTransportConfig>,
 ) -> Result<Channel> {
-    let start = Instant::now();
-    let target_id = target.id;
-    let connect_future = connect_inner(endpoint, target, alpn, transport_config);
-
-    let channel = if let Some(timeout) = connect_timeout {
-        tokio::time::timeout(timeout, connect_future)
-            .await
-            .map_err(|_| Error::connection(format!("connection timed out after {timeout:?}")))?
-    } else {
-        connect_future.await
-    }?;
-
-    debug!(
-        peer_id = %target_id,
-        connect_timeout_ms = connect_timeout.map(|timeout| timeout.as_millis()),
-        total_connect_ms = start.elapsed().as_millis(),
-        "iroh tonic connect completed"
+    let span = tracing::info_span!(
+        "iroh.connect",
+        peer_id = %target.id,
+        alpn = %String::from_utf8_lossy(&alpn),
+        timeout_ms = connect_timeout.map(|t| t.as_millis().try_into().unwrap_or(u64::MAX)),
     );
-    Ok(channel)
+
+    async {
+        let connect_future = connect_inner(endpoint, target, alpn, transport_config);
+
+        let channel = if let Some(timeout) = connect_timeout {
+            tokio::time::timeout(timeout, connect_future)
+                .await
+                .map_err(|_| Error::connection(format!("connection timed out after {timeout:?}")))?
+        } else {
+            connect_future.await
+        }?;
+
+        Ok(channel)
+    }
+    .instrument(span)
+    .await
 }
 
 async fn connect_inner(
@@ -251,10 +254,8 @@ async fn connect_inner(
     alpn: Vec<u8>,
     transport_config: Option<QuicTransportConfig>,
 ) -> Result<Channel> {
-    let start = Instant::now();
-    debug!(peer_id = %target.id, "connecting to peer");
-
     let target_id = target.id;
+    debug!(peer_id = %target_id, "connecting to peer");
 
     // Create a dummy endpoint URI (not used by connector)
     let channel = Endpoint::try_from("http://[::]:50051")?
@@ -274,20 +275,17 @@ async fn connect_inner(
                         .connect_with_opts(target.clone(), &alpn, opts)
                         .await
                         .map_err(|e| {
-                            // Initial connection setup error (node lookup, etc.)
                             std::io::Error::new(std::io::ErrorKind::ConnectionRefused, e)
                         })?;
                     connecting.await.map_err(connecting_error_to_io)?
                 } else {
                     endpoint.connect(target.clone(), &alpn).await.map_err(|e| {
-                        // This could be various errors - use ConnectionRefused as default
                         std::io::Error::new(std::io::ErrorKind::ConnectionRefused, e)
                     })?
                 };
                 // Open a bidirectional stream for this gRPC call
                 let (send, recv) = connection.open_bi().await.map_err(connection_error_to_io)?;
 
-                // Create the stream with context
                 let context = crate::stream::IrohContext {
                     node_id: target_id,
                     connection: connection.clone(),
@@ -301,10 +299,6 @@ async fn connect_inner(
         }))
         .await?;
 
-    info!(
-        peer_id = %target_id,
-        connect_inner_ms = start.elapsed().as_millis(),
-        "successfully connected to peer"
-    );
+    debug!(peer_id = %target_id, "connected to peer");
     Ok(channel)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -72,6 +72,8 @@ pub mod transport;
 #[cfg(any(feature = "server", feature = "discovery"))]
 mod user_data;
 
+#[cfg(feature = "otel")]
+pub mod otel;
 #[cfg(feature = "discovery")]
 pub mod swarm;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,7 @@
 //! - `client`: Outbound connectors (`IrohConnect`, `connect_alpn`).
 //! - `server`: Inbound transport runtime (`TransportBuilder`, `TransportGuard`).
 //! - `discovery`: Peer discovery/swarm support (depends on `client`).
+//! - `otel`: OpenTelemetry trace context propagation interceptors.
 //!
 //! # Example
 //!

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -1,0 +1,106 @@
+//! Optional OpenTelemetry trace context propagation for tonic gRPC.
+//!
+//! Provides tonic interceptors that inject/extract W3C `traceparent`/`tracestate`
+//! headers into gRPC metadata, enabling distributed tracing across iroh P2P calls.
+//!
+//! # Client-side injection
+//!
+//! ```rust,no_run
+//! use tonic_iroh_transport::otel::TraceContextInjector;
+//!
+//! // Wrap a client with the injector so outgoing calls carry the current trace context
+//! // let client = MyServiceClient::with_interceptor(channel, TraceContextInjector);
+//! ```
+//!
+//! # Server-side extraction
+//!
+//! ```rust,no_run
+//! use tonic::service::interceptor::InterceptedService;
+//! use tonic_iroh_transport::otel::TraceContextExtractor;
+//!
+//! // Wrap a server so incoming trace context is attached to request extensions
+//! // let service = InterceptedService::new(my_server, TraceContextExtractor);
+//! ```
+
+use opentelemetry::propagation::{Extractor, Injector};
+use tonic::metadata::MetadataMap;
+use tonic::{Request, Status};
+
+/// Client-side interceptor that injects the current OpenTelemetry trace context
+/// into outgoing gRPC metadata as W3C `traceparent`/`tracestate` headers.
+///
+/// Requires a [`TextMapPropagator`](opentelemetry::propagation::TextMapPropagator)
+/// to be registered via [`opentelemetry::global::set_text_map_propagator`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TraceContextInjector;
+
+impl tonic::service::Interceptor for TraceContextInjector {
+    fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
+        let cx = opentelemetry::Context::current();
+        opentelemetry::global::get_text_map_propagator(|propagator| {
+            propagator.inject_context(&cx, &mut MetadataInjector(request.metadata_mut()));
+        });
+        Ok(request)
+    }
+}
+
+/// Server-side interceptor that extracts W3C trace context from incoming gRPC
+/// metadata and stores it in request extensions as an [`opentelemetry::Context`].
+///
+/// Downstream handlers can retrieve the context with:
+/// ```rust,ignore
+/// let parent_cx = request.extensions().get::<opentelemetry::Context>();
+/// ```
+///
+/// Requires a [`TextMapPropagator`](opentelemetry::propagation::TextMapPropagator)
+/// to be registered via [`opentelemetry::global::set_text_map_propagator`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TraceContextExtractor;
+
+impl tonic::service::Interceptor for TraceContextExtractor {
+    fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
+        let cx = opentelemetry::global::get_text_map_propagator(|propagator| {
+            propagator.extract(&MetadataExtractorRef(request.metadata()))
+        });
+        request.extensions_mut().insert(cx);
+        Ok(request)
+    }
+}
+
+/// [`Injector`] adapter for [`tonic::metadata::MetadataMap`].
+///
+/// Use this directly if you need custom propagation logic beyond the
+/// provided interceptors.
+pub struct MetadataInjector<'a>(pub &'a mut MetadataMap);
+
+impl Injector for MetadataInjector<'_> {
+    fn set(&mut self, key: &str, value: String) {
+        if let Ok(key) = tonic::metadata::MetadataKey::from_bytes(key.as_bytes()) {
+            if let Ok(val) = tonic::metadata::MetadataValue::try_from(&value) {
+                self.0.insert(key, val);
+            }
+        }
+    }
+}
+
+/// [`Extractor`] adapter for [`tonic::metadata::MetadataMap`].
+///
+/// Use this directly if you need custom propagation logic beyond the
+/// provided interceptors.
+pub struct MetadataExtractorRef<'a>(pub &'a MetadataMap);
+
+impl Extractor for MetadataExtractorRef<'_> {
+    fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).and_then(|v| v.to_str().ok())
+    }
+
+    fn keys(&self) -> Vec<&str> {
+        self.0
+            .keys()
+            .filter_map(|k| match k {
+                tonic::metadata::KeyRef::Ascii(key) => Some(key.as_str()),
+                tonic::metadata::KeyRef::Binary(_) => None,
+            })
+            .collect()
+    }
+}

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -1,7 +1,7 @@
 //! Optional OpenTelemetry trace context propagation for tonic gRPC.
 //!
-//! Provides tonic interceptors that inject/extract W3C `traceparent`/`tracestate`
-//! headers into gRPC metadata, enabling distributed tracing across iroh P2P calls.
+//! Provides a client-side interceptor and a server-side tower layer for
+//! propagating W3C `traceparent`/`tracestate` headers across iroh P2P calls.
 //!
 //! # Client-side injection
 //!
@@ -12,18 +12,16 @@
 //! // let client = MyServiceClient::with_interceptor(channel, TraceContextInjector);
 //! ```
 //!
-//! # Server-side extraction
+//! # Server-side span parenting
 //!
 //! ```rust,no_run
-//! use tonic::service::interceptor::InterceptedService;
-//! use tonic_iroh_transport::otel::TraceContextExtractor;
+//! use tonic_iroh_transport::otel::TraceContextLayer;
 //!
-//! // Wrap a server so incoming trace context is attached to request extensions
-//! // let service = InterceptedService::new(my_server, TraceContextExtractor);
+//! // Wrap a server so incoming requests run inside a span parented to the caller's trace
+//! // let service = TraceContextLayer.layer(my_server);
 //! ```
 
-use opentelemetry::propagation::{Extractor, Injector};
-use tonic::metadata::MetadataMap;
+use opentelemetry::propagation::Injector;
 use tonic::{Request, Status};
 
 /// Client-side interceptor that injects the current OpenTelemetry trace context
@@ -44,37 +42,8 @@ impl tonic::service::Interceptor for TraceContextInjector {
     }
 }
 
-/// Server-side interceptor that extracts W3C trace context from incoming gRPC
-/// metadata and stores it in request extensions as an [`opentelemetry::Context`].
-///
-/// Downstream handlers can retrieve the context with:
-/// ```rust,ignore
-/// let parent_cx = request.extensions().get::<opentelemetry::Context>();
-/// ```
-///
-/// Requires a [`TextMapPropagator`](opentelemetry::propagation::TextMapPropagator)
-/// to be registered via [`opentelemetry::global::set_text_map_propagator`].
-#[derive(Clone, Copy, Debug, Default)]
-pub struct TraceContextExtractor;
-
-impl tonic::service::Interceptor for TraceContextExtractor {
-    fn call(&mut self, mut request: Request<()>) -> Result<Request<()>, Status> {
-        let cx = opentelemetry::global::get_text_map_propagator(|propagator| {
-            propagator.extract(&MetadataExtractorRef(request.metadata()))
-        });
-        request.extensions_mut().insert(cx);
-        Ok(request)
-    }
-}
-
 /// [`Injector`] adapter for [`tonic::metadata::MetadataMap`].
-///
-/// Use this directly if you need custom propagation logic beyond the
-/// provided interceptors.
-pub struct MetadataInjector<'a>(
-    /// The metadata map to inject headers into.
-    pub &'a mut MetadataMap,
-);
+struct MetadataInjector<'a>(&'a mut tonic::metadata::MetadataMap);
 
 impl Injector for MetadataInjector<'_> {
     fn set(&mut self, key: &str, value: String) {
@@ -86,43 +55,125 @@ impl Injector for MetadataInjector<'_> {
     }
 }
 
-/// [`Extractor`] adapter for [`tonic::metadata::MetadataMap`].
-///
-/// Use this directly if you need custom propagation logic beyond the
-/// provided interceptors.
-pub struct MetadataExtractorRef<'a>(
-    /// The metadata map to extract headers from.
-    pub &'a MetadataMap,
-);
+// ---------------------------------------------------------------------------
+// Tower layer for automatic server-side span parenting
+// ---------------------------------------------------------------------------
 
-impl Extractor for MetadataExtractorRef<'_> {
-    fn get(&self, key: &str) -> Option<&str> {
-        self.0.get(key).and_then(|v| v.to_str().ok())
+#[cfg(feature = "server")]
+mod layer {
+    use std::future::Future;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+
+    use opentelemetry::propagation::Extractor;
+    use tracing::Instrument;
+    use tracing_opentelemetry::OpenTelemetrySpanExt;
+
+    /// A tower [`Layer`](tower::Layer) that extracts W3C trace context from
+    /// incoming gRPC requests and runs the inner service inside a tracing span
+    /// parented to the caller's trace.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use tonic_iroh_transport::otel::TraceContextLayer;
+    ///
+    /// let transport = TransportBuilder::new(endpoint)
+    ///     .add_rpc(TraceContextLayer.layer(MyServer::new(my_impl)))
+    ///     .spawn()
+    ///     .await?;
+    /// ```
+    #[derive(Clone, Copy, Debug, Default)]
+    pub struct TraceContextLayer;
+
+    impl TraceContextLayer {
+        /// Wrap a service so incoming requests run inside a span parented to the
+        /// caller's trace context.
+        pub fn layer<S>(&self, inner: S) -> TraceContextService<S> {
+            TraceContextService { inner }
+        }
     }
 
-    fn keys(&self) -> Vec<&str> {
-        self.0
-            .keys()
-            .filter_map(|k| match k {
-                tonic::metadata::KeyRef::Ascii(key) => Some(key.as_str()),
-                tonic::metadata::KeyRef::Binary(_) => None,
-            })
-            .collect()
+    impl<S> tower::Layer<S> for TraceContextLayer {
+        type Service = TraceContextService<S>;
+
+        fn layer(&self, inner: S) -> Self::Service {
+            TraceContextService { inner }
+        }
+    }
+
+    /// Tower service created by [`TraceContextLayer`].
+    ///
+    /// Extracts W3C trace context from HTTP headers and instruments the inner
+    /// service call with a span parented to the extracted context.
+    #[derive(Clone, Debug)]
+    pub struct TraceContextService<S> {
+        inner: S,
+    }
+
+    impl<S: tonic::server::NamedService> tonic::server::NamedService for TraceContextService<S> {
+        const NAME: &'static str = S::NAME;
+    }
+
+    impl<S, B> tower::Service<http::Request<B>> for TraceContextService<S>
+    where
+        S: tower::Service<http::Request<B>> + Clone + Send + 'static,
+        S::Future: Send + 'static,
+        B: Send + 'static,
+    {
+        type Response = S::Response;
+        type Error = S::Error;
+        type Future = Pin<Box<dyn Future<Output = Result<Self::Response, Self::Error>> + Send>>;
+
+        fn poll_ready(&mut self, cx: &mut Context<'_>) -> Poll<Result<(), Self::Error>> {
+            self.inner.poll_ready(cx)
+        }
+
+        fn call(&mut self, request: http::Request<B>) -> Self::Future {
+            let parent_cx = opentelemetry::global::get_text_map_propagator(|propagator| {
+                propagator.extract(&HeaderExtractor(request.headers()))
+            });
+
+            let span = tracing::info_span!(
+                "grpc.server",
+                otel.kind = "server",
+                rpc.method = request.uri().path(),
+            );
+            let _ = span.set_parent(parent_cx);
+
+            let clone = self.inner.clone();
+            let mut inner = std::mem::replace(&mut self.inner, clone);
+
+            Box::pin(inner.call(request).instrument(span))
+        }
+    }
+
+    /// [`Extractor`] adapter for [`http::HeaderMap`].
+    struct HeaderExtractor<'a>(&'a http::HeaderMap);
+
+    impl Extractor for HeaderExtractor<'_> {
+        fn get(&self, key: &str) -> Option<&str> {
+            self.0.get(key).and_then(|v| v.to_str().ok())
+        }
+
+        fn keys(&self) -> Vec<&str> {
+            self.0.keys().map(http::HeaderName::as_str).collect()
+        }
     }
 }
+
+#[cfg(feature = "server")]
+pub use layer::{TraceContextLayer, TraceContextService};
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opentelemetry::propagation::TextMapPropagator;
-    use opentelemetry_sdk::propagation::TraceContextPropagator;
-    use tonic::service::Interceptor;
+    use opentelemetry::propagation::Injector;
+    use tonic::metadata::MetadataMap;
 
     #[test]
     fn injector_sets_traceparent_header() {
         let mut metadata = MetadataMap::new();
-
-        // Inject a known context with a valid traceparent
         let mut injector = MetadataInjector(&mut metadata);
         injector.set(
             "traceparent",
@@ -136,76 +187,40 @@ mod tests {
     }
 
     #[test]
-    fn extractor_reads_traceparent_header() {
-        let mut metadata = MetadataMap::new();
-        metadata.insert(
-            "traceparent",
-            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
-                .parse()
-                .unwrap(),
-        );
+    fn injector_round_trip_via_interceptor() {
+        use opentelemetry::propagation::{Extractor, TextMapPropagator};
+        use opentelemetry_sdk::propagation::TraceContextPropagator;
 
-        let extractor = MetadataExtractorRef(&metadata);
-        assert_eq!(
-            extractor.get("traceparent").unwrap(),
-            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
-        );
-        assert!(extractor.keys().contains(&"traceparent"));
-    }
-
-    #[test]
-    fn round_trip_inject_extract() {
         let propagator = TraceContextPropagator::new();
-
-        // Inject a context into metadata
-        let mut metadata = MetadataMap::new();
         let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
-        let mut inject_map = MetadataMap::new();
-        inject_map.insert("traceparent", traceparent.parse().unwrap());
 
-        // Extract a context from the injected metadata
-        let extracted_cx = propagator.extract(&MetadataExtractorRef(&inject_map));
+        // Simulate: traceparent → metadata → extract context → re-inject → verify
+        let mut src = MetadataMap::new();
+        src.insert("traceparent", traceparent.parse().unwrap());
 
-        // Re-inject the extracted context into fresh metadata
-        propagator.inject_context(&extracted_cx, &mut MetadataInjector(&mut metadata));
+        struct MapExtractor<'a>(&'a MetadataMap);
+        impl Extractor for MapExtractor<'_> {
+            fn get(&self, key: &str) -> Option<&str> {
+                self.0.get(key).and_then(|v| v.to_str().ok())
+            }
+            fn keys(&self) -> Vec<&str> {
+                self.0
+                    .keys()
+                    .filter_map(|k| match k {
+                        tonic::metadata::KeyRef::Ascii(k) => Some(k.as_str()),
+                        tonic::metadata::KeyRef::Binary(_) => None,
+                    })
+                    .collect()
+            }
+        }
 
-        // The traceparent should survive the round trip
-        assert_eq!(
-            metadata.get("traceparent").unwrap().to_str().unwrap(),
-            traceparent
-        );
-    }
+        let cx = propagator.extract(&MapExtractor(&src));
 
-    #[test]
-    fn interceptor_inject_extract_round_trip() {
-        let propagator = TraceContextPropagator::new();
-        opentelemetry::global::set_text_map_propagator(propagator);
-
-        // Simulate client-side injection
-        let mut client_request = Request::new(());
-        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
-        client_request
-            .metadata_mut()
-            .insert("traceparent", traceparent.parse().unwrap());
-
-        // Extract on server side
-        let mut extractor = TraceContextExtractor;
-        let server_request = extractor.call(client_request).unwrap();
-
-        // Verify the OTel context was stored in extensions
-        let cx = server_request
-            .extensions()
-            .get::<opentelemetry::Context>()
-            .expect("context should be in extensions");
-
-        // Re-inject from the extracted context
-        let mut metadata = MetadataMap::new();
-        opentelemetry::global::get_text_map_propagator(|p| {
-            p.inject_context(cx, &mut MetadataInjector(&mut metadata));
-        });
+        let mut dst = MetadataMap::new();
+        propagator.inject_context(&cx, &mut MetadataInjector(&mut dst));
 
         assert_eq!(
-            metadata.get("traceparent").unwrap().to_str().unwrap(),
+            dst.get("traceparent").unwrap().to_str().unwrap(),
             traceparent
         );
     }

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -124,7 +124,10 @@ mod tests {
 
         // Inject a known context with a valid traceparent
         let mut injector = MetadataInjector(&mut metadata);
-        injector.set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".into());
+        injector.set(
+            "traceparent",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".into(),
+        );
 
         assert_eq!(
             metadata.get("traceparent").unwrap().to_str().unwrap(),
@@ -137,7 +140,9 @@ mod tests {
         let mut metadata = MetadataMap::new();
         metadata.insert(
             "traceparent",
-            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".parse().unwrap(),
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+                .parse()
+                .unwrap(),
         );
 
         let extractor = MetadataExtractorRef(&metadata);

--- a/src/otel.rs
+++ b/src/otel.rs
@@ -71,7 +71,10 @@ impl tonic::service::Interceptor for TraceContextExtractor {
 ///
 /// Use this directly if you need custom propagation logic beyond the
 /// provided interceptors.
-pub struct MetadataInjector<'a>(pub &'a mut MetadataMap);
+pub struct MetadataInjector<'a>(
+    /// The metadata map to inject headers into.
+    pub &'a mut MetadataMap,
+);
 
 impl Injector for MetadataInjector<'_> {
     fn set(&mut self, key: &str, value: String) {
@@ -87,7 +90,10 @@ impl Injector for MetadataInjector<'_> {
 ///
 /// Use this directly if you need custom propagation logic beyond the
 /// provided interceptors.
-pub struct MetadataExtractorRef<'a>(pub &'a MetadataMap);
+pub struct MetadataExtractorRef<'a>(
+    /// The metadata map to extract headers from.
+    pub &'a MetadataMap,
+);
 
 impl Extractor for MetadataExtractorRef<'_> {
     fn get(&self, key: &str) -> Option<&str> {
@@ -102,5 +108,100 @@ impl Extractor for MetadataExtractorRef<'_> {
                 tonic::metadata::KeyRef::Binary(_) => None,
             })
             .collect()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use opentelemetry::propagation::TextMapPropagator;
+    use opentelemetry_sdk::propagation::TraceContextPropagator;
+    use tonic::service::Interceptor;
+
+    #[test]
+    fn injector_sets_traceparent_header() {
+        let mut metadata = MetadataMap::new();
+
+        // Inject a known context with a valid traceparent
+        let mut injector = MetadataInjector(&mut metadata);
+        injector.set("traceparent", "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".into());
+
+        assert_eq!(
+            metadata.get("traceparent").unwrap().to_str().unwrap(),
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        );
+    }
+
+    #[test]
+    fn extractor_reads_traceparent_header() {
+        let mut metadata = MetadataMap::new();
+        metadata.insert(
+            "traceparent",
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01".parse().unwrap(),
+        );
+
+        let extractor = MetadataExtractorRef(&metadata);
+        assert_eq!(
+            extractor.get("traceparent").unwrap(),
+            "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+        );
+        assert!(extractor.keys().contains(&"traceparent"));
+    }
+
+    #[test]
+    fn round_trip_inject_extract() {
+        let propagator = TraceContextPropagator::new();
+
+        // Inject a context into metadata
+        let mut metadata = MetadataMap::new();
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        let mut inject_map = MetadataMap::new();
+        inject_map.insert("traceparent", traceparent.parse().unwrap());
+
+        // Extract a context from the injected metadata
+        let extracted_cx = propagator.extract(&MetadataExtractorRef(&inject_map));
+
+        // Re-inject the extracted context into fresh metadata
+        propagator.inject_context(&extracted_cx, &mut MetadataInjector(&mut metadata));
+
+        // The traceparent should survive the round trip
+        assert_eq!(
+            metadata.get("traceparent").unwrap().to_str().unwrap(),
+            traceparent
+        );
+    }
+
+    #[test]
+    fn interceptor_inject_extract_round_trip() {
+        let propagator = TraceContextPropagator::new();
+        opentelemetry::global::set_text_map_propagator(propagator);
+
+        // Simulate client-side injection
+        let mut client_request = Request::new(());
+        let traceparent = "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01";
+        client_request
+            .metadata_mut()
+            .insert("traceparent", traceparent.parse().unwrap());
+
+        // Extract on server side
+        let mut extractor = TraceContextExtractor;
+        let server_request = extractor.call(client_request).unwrap();
+
+        // Verify the OTel context was stored in extensions
+        let cx = server_request
+            .extensions()
+            .get::<opentelemetry::Context>()
+            .expect("context should be in extensions");
+
+        // Re-inject from the extracted context
+        let mut metadata = MetadataMap::new();
+        opentelemetry::global::get_text_map_propagator(|p| {
+            p.inject_context(cx, &mut MetadataInjector(&mut metadata));
+        });
+
+        assert_eq!(
+            metadata.get("traceparent").unwrap().to_str().unwrap(),
+            traceparent
+        );
     }
 }

--- a/src/pool.rs
+++ b/src/pool.rs
@@ -322,6 +322,11 @@ impl Ctx {
     /// Per-connection actor: establishes a connection, hands out refs, manages
     /// idle timeout, and watches for remote close.
     #[allow(clippy::too_many_lines)]
+    #[tracing::instrument(
+        name = "pool.connection",
+        skip(self, pool_tx, shutdown, actor_tx, rx),
+        fields(%node_id, generation),
+    )]
     async fn run_connection(
         self: Arc<Self>,
         pool_tx: mpsc::Sender<Msg>,
@@ -700,6 +705,7 @@ impl ConnectionPool {
     ///
     /// Returns [`PoolError`] if the pool is shut down, the connection times
     /// out, a pooled actor is saturated, or the connection limit is reached.
+    #[tracing::instrument(name = "pool.get_or_connect", skip(self), fields(peer_id = %id))]
     pub async fn get_or_connect(&self, id: EndpointId) -> Result<ConnectionRef, PoolError> {
         let tx = self.shared.tx()?;
 
@@ -773,6 +779,7 @@ impl ConnectionPool {
     ///
     /// Returns an error if the connection cannot be established or the tonic
     /// channel cannot be created.
+    #[tracing::instrument(name = "pool.channel", skip(self), fields(peer_id = %id))]
     pub async fn channel(&self, id: EndpointId) -> crate::Result<Channel> {
         let pool = self.clone();
         let channel = tonic::transport::Endpoint::try_from("http://[::]:50051")?

--- a/src/server.rs
+++ b/src/server.rs
@@ -6,7 +6,7 @@ use std::pin::Pin;
 use std::task::{Context, Poll};
 use tokio::sync::mpsc::{self, error::TrySendError};
 use tokio_stream::wrappers::ReceiverStream;
-use tracing::{debug, error, warn};
+use tracing::{debug, error, warn, Instrument};
 
 pub(crate) const DEFAULT_INCOMING_BUFFER_CAPACITY: usize = 256;
 const OVERLOAD_STREAM_ERROR_CODE: u32 = 1;
@@ -76,52 +76,54 @@ impl iroh::protocol::ProtocolHandler for GrpcProtocolHandler {
 
         async move {
             let remote_node_id = connection.remote_id();
+            let span = tracing::info_span!(
+                "iroh.accept",
+                peer_id = %remote_node_id,
+                service = %service_name,
+            );
 
-            loop {
-                // The router already runs each accept future on its own task.
-                // Keeping the stream loop in this future lets router shutdown
-                // own the task lifecycle instead of leaving a detached task behind.
-                if let Ok((mut send, mut recv)) = connection.accept_bi().await {
-                    debug!("Accepted new stream for service '{}'", service_name);
+            async {
+                loop {
+                    // The router already runs each accept future on its own task.
+                    // Keeping the stream loop in this future lets router shutdown
+                    // own the task lifecycle instead of leaving a detached task behind.
+                    if let Ok((mut send, mut recv)) = connection.accept_bi().await {
+                        debug!("accepted new stream");
 
-                    match sender.try_reserve() {
-                        Ok(permit) => {
-                            let stream = IrohStream::new(
-                                send,
-                                recv,
-                                IrohContext {
-                                    node_id: remote_node_id,
-                                    connection: connection.clone(),
-                                    established_at: std::time::Instant::now(),
-                                    alpn: connection.alpn().to_vec(),
-                                },
-                            );
-                            permit.send(Ok(stream));
+                        match sender.try_reserve() {
+                            Ok(permit) => {
+                                let stream = IrohStream::new(
+                                    send,
+                                    recv,
+                                    IrohContext {
+                                        node_id: remote_node_id,
+                                        connection: connection.clone(),
+                                        established_at: std::time::Instant::now(),
+                                        alpn: connection.alpn().to_vec(),
+                                    },
+                                );
+                                permit.send(Ok(stream));
+                            }
+                            Err(TrySendError::Full(())) => {
+                                warn!("dropping overloaded stream");
+                                reject_stream(&mut send, &mut recv);
+                            }
+                            Err(TrySendError::Closed(())) => {
+                                error!("channel closed, cannot forward stream");
+                                reject_stream(&mut send, &mut recv);
+                                break;
+                            }
                         }
-                        Err(TrySendError::Full(())) => {
-                            warn!(
-                                "Dropping overloaded stream for service '{}' from peer: {}",
-                                service_name, remote_node_id
-                            );
-                            reject_stream(&mut send, &mut recv);
-                        }
-                        Err(TrySendError::Closed(())) => {
-                            error!(
-                                "Failed to forward stream to handler for service '{}': channel closed",
-                                service_name
-                            );
-                            reject_stream(&mut send, &mut recv);
-                            break;
-                        }
+                    } else {
+                        debug!("connection closed");
+                        break;
                     }
-                } else {
-                    // Connection closed or error
-                    debug!("Connection closed for service '{}'", service_name);
-                    break;
                 }
-            }
 
-            Ok::<(), iroh::protocol::AcceptError>(())
+                Ok::<(), iroh::protocol::AcceptError>(())
+            }
+            .instrument(span)
+            .await
         }
     }
 

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -130,6 +130,7 @@ impl TransportBuilder {
     ///
     /// Returns an error if ALPN metadata encoding fails or the router cannot be built.
     #[allow(clippy::unused_async)]
+    #[tracing::instrument(name = "transport.spawn", skip(self), fields(service_count = self.services.len()))]
     pub async fn spawn(self) -> Result<TransportGuard> {
         let (shutdown_tx, _) = broadcast::channel(1);
         let (incoming, sender) = IrohIncoming::new(self.incoming_buffer_capacity);


### PR DESCRIPTION
- Add `otel` feature with optional `opentelemetry` dependency
- Add TraceContextInjector/Extractor interceptors for W3C traceparent propagation
- Add MetadataInjector/MetadataExtractorRef adapters for tonic MetadataMap
- Instrument client connect, server accept, pool operations, and transport spawn with tracing spans