### PR TITLE
feat: granular iroh feature passthroughs; cover --features otel in CI

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tonic-iroh-transport"
 authors = ["George Whewell <george@hellas.ai>"]
-version = "0.9.1"
+version = "0.9.2"
 edition = "2021"
 description = "Transport layer for using tonic gRPC over iroh p2p connections"
 license = "MIT OR Apache-2.0"
@@ -19,17 +19,20 @@ default = ["client", "server", "native-defaults"]
 # Forwards iroh's native-only default features. Native consumers get these
 # implicitly via `default = [...]`; wasm consumers drop them by setting
 # `default-features = false` on this crate and either re-enabling
-# `native-defaults` or picking just `tls-ring` / `tls-aws-lc-rs`
-# (optionally configuring their own `CryptoProvider` via
-# `iroh::endpoint::Builder::crypto_provider`).
+# `native-defaults` or picking the granular features below (or just
+# `tls-ring` / `tls-aws-lc-rs` and configuring their own `CryptoProvider`
+# via `iroh::endpoint::Builder::crypto_provider`).
 native-defaults = [
     "tls-ring",
-    "iroh/portmapper",
-    "iroh/metrics",
-    "iroh/fast-apple-datapath",
+    "portmapper",
+    "metrics",
+    "fast-apple-datapath",
 ]
 tls-ring = ["iroh/tls-ring"]
 tls-aws-lc-rs = ["iroh/tls-aws-lc-rs"]
+portmapper = ["iroh/portmapper"]
+metrics = ["iroh/metrics"]
+fast-apple-datapath = ["iroh/fast-apple-datapath"]
 client = [
     "dep:h2",
     "dep:http",
@@ -100,7 +103,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 async-stream = { version = "0.3", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 postcard = { version = "1", optional = true, features = ["alloc"] }
-opentelemetry = { version = "0.31", optional = true, default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.32", optional = true, default-features = false, features = ["trace"] }
 tracing-opentelemetry = { version = "0.32", optional = true, default-features = false }
 
 [dev-dependencies]
@@ -110,7 +113,7 @@ tracing-subscriber = "0.3"
 anyhow = "1.0"
 async-trait = "0.1"
 test-log = "0.2"
-opentelemetry_sdk = { version = "0.31", features = ["trace"] }
+opentelemetry_sdk = { version = "0.32", features = ["trace"] }
 
 # Example dependencies
 clap = { version = "4.5", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,7 +103,7 @@ sha2 = { version = "0.10", optional = true, default-features = false }
 async-stream = { version = "0.3", optional = true }
 serde = { version = "1", optional = true, features = ["derive"] }
 postcard = { version = "1", optional = true, features = ["alloc"] }
-opentelemetry = { version = "0.32", optional = true, default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.31", optional = true, default-features = false, features = ["trace"] }
 tracing-opentelemetry = { version = "0.32", optional = true, default-features = false }
 
 [dev-dependencies]
@@ -113,7 +113,7 @@ tracing-subscriber = "0.3"
 anyhow = "1.0"
 async-trait = "0.1"
 test-log = "0.2"
-opentelemetry_sdk = { version = "0.32", features = ["trace"] }
+opentelemetry_sdk = { version = "0.31", features = ["trace"] }
 
 # Example dependencies
 clap = { version = "4.5", features = ["derive"] }

--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,14 @@ test:
 	@echo "Running tests..."
 	cargo test
 
+# Run tests with the `otel` feature so the trace-context propagation paths
+# (src/otel.rs) are actually compiled and exercised. Catches API breakages
+# from opentelemetry / tracing-opentelemetry dep bumps, which the default
+# `cargo test` would otherwise silently miss.
+test-otel:
+	@echo "Running tests (--features otel)..."
+	cargo test --features otel
+
 # Run tests with output
 test-verbose:
 	@echo "Running tests (verbose)..."
@@ -149,8 +157,8 @@ check-all: check check-examples check-wasm
 # Full lint including examples and protos
 lint-all: lint lint-examples lint-proto
 
-# Full test including examples
-test-all: test test-examples
+# Full test including examples and otel-feature path
+test-all: test test-otel test-examples
 
 # Full doc generation including examples
 doc-all: doc doc-examples
@@ -199,8 +207,9 @@ help:
 	@echo "  lint-examples    - Lint examples only"
 	@echo "  lint-proto       - Lint proto files with buf"
 	@echo "  test             - Run tests"
+	@echo "  test-otel        - Run tests with --features otel (covers src/otel.rs)"
 	@echo "  test-verbose     - Run tests with output"
-	@echo "  test-all         - Run tests for main crate and examples"
+	@echo "  test-all         - Run tests for main crate (default + otel) and examples"
 	@echo "  test-examples    - Run tests for examples only"
 	@echo "  doc              - Generate docs for main crate"
 	@echo "  doc-full         - Generate docs for main crate with dependencies"


### PR DESCRIPTION
## Summary
- Expose `portmapper`, `metrics`, and `fast-apple-datapath` as standalone features, so consumers can opt into individual iroh capabilities (e.g. metrics-only) without taking the full `native-defaults` bundle. Matters for wasm and minimal-build targets, and unblocks downstream feature gating (e.g. enabling iroh metrics conditionally on a consumer's `otel` feature).
- `native-defaults` is rewritten on top of the new feature names so it remains a single-flag shorthand for the existing default set — no behavior change for consumers using defaults.
- Bump crate version 0.9.1 → 0.9.2 (additive features, non-breaking).
- Add `make test-otel` (`cargo test --features otel`) and fold it into `test-all`, so `src/otel.rs` is actually compiled and tested in CI. The existing `cargo test` only exercises default features and would silently miss API-level breakage in the `otel`-gated propagation glue.

## Note on opentelemetry version
An earlier draft of this branch also bumped `opentelemetry` 0.31 → 0.32. The new `make test-otel` step caught that this is broken: `tracing-opentelemetry 0.32.1` (latest) still pins `opentelemetry 0.31`, so the bump produced two versions of opentelemetry in the dep tree and `src/otel.rs:142` failed to type-check (`set_parent` expected the 0.31 `Context`, got 0.32). Reverted; we'll take 0.32 once `tracing-opentelemetry` releases a version that pins it.

## Test plan
- [x] \`make fmt-check-all\`
- [x] \`make lint-all\` (incl. \`buf lint\` on protos)
- [x] \`make test-all\` — now includes \`test-otel\`
- [x] \`make doc-check-all\`
- [x] \`make build\` + \`make examples\`
- [ ] \`make check-wasm\` (deferred to CI — local nix toolchain doesn't include wasm32 target)